### PR TITLE
Add difficulty and saving feature

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 import json
-from typing import List, Dict, Any
+import random
+from typing import Any, Dict, List
 
 
 @dataclass
@@ -58,27 +60,62 @@ def _calculate_clues(
     return clues
 
 
-def generate_puzzle(rows: int, cols: int) -> Puzzle:
-    """簡易な盤面を生成して返す"""
+ALLOWED_DIFFICULTIES = {"easy", "normal", "hard", "expert"}
+
+
+def generate_puzzle(
+    rows: int, cols: int, difficulty: str = "normal", *, seed: int | None = None
+) -> Puzzle:
+    """簡易な盤面を生成して返す
+
+    :param rows: 盤面の行数
+    :param cols: 盤面の列数
+    :param difficulty: 難易度ラベル
+    :param seed: 乱数シード。再現したいときに指定する
+    """
+
+    if difficulty not in ALLOWED_DIFFICULTIES:
+        raise ValueError(f"difficulty は {ALLOWED_DIFFICULTIES} のいずれかで指定")
+
+    if seed is not None:
+        random.seed(seed)
+
     size = PuzzleSize(rows=rows, cols=cols)
     edges = _create_empty_edges(size)
     _add_outer_loop(edges, size)
     clues = _calculate_clues(edges, size)
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     puzzle: Puzzle = {
-        "id": f"sl_{rows}x{cols}_sample_{int(datetime.utcnow().timestamp())}",
+        "id": f"sl_{rows}x{cols}_{difficulty}_{timestamp}",
         "size": {"rows": rows, "cols": cols},
         "clues": clues,
         "solutionEdges": edges,
-        "difficulty": "easy",
+        "difficulty": difficulty,
         "createdBy": "auto-gen-v1",
         "createdAt": datetime.utcnow().date().isoformat(),
     }
     return puzzle
 
 
+def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:
+    """パズルを JSON 形式で保存する
+
+    :param puzzle: generate_puzzle の戻り値
+    :param directory: 保存先ディレクトリ
+    :return: 保存したファイルのパス
+    """
+    path = Path(directory)
+    path.mkdir(parents=True, exist_ok=True)
+    fname = f"{puzzle['id']}.json"
+    file_path = path / fname
+    with file_path.open("w", encoding="utf-8") as fp:
+        json.dump(puzzle, fp, ensure_ascii=False, indent=2)
+    return file_path
+
+
 if __name__ == "__main__":
-    # 実行例：生成したパズルを JSON 形式で保存
-    pzl = generate_puzzle(4, 4)
-    with open("data/sample.json", "w", encoding="utf-8") as f:
-        json.dump(pzl, f, ensure_ascii=False, indent=2)
-    print("sample.json を作成しました")
+    # 実行例：生成したパズルを保存
+    pzl = generate_puzzle(4, 4, difficulty="easy")
+    path = save_puzzle(pzl)
+    print(f"{path} を作成しました")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -18,3 +18,12 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
     file.write_text(data, encoding="utf-8")
     loaded = json.loads(file.read_text(encoding="utf-8"))
     assert loaded["size"] == {"rows": 4, "cols": 4}
+    assert loaded["difficulty"] == "normal"
+
+
+def test_save_puzzle(tmp_path: Path) -> None:
+    puzzle = generator.generate_puzzle(4, 4, difficulty="easy")
+    path = generator.save_puzzle(puzzle, directory=tmp_path)
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["id"].startswith("sl_4x4_easy_")


### PR DESCRIPTION
## Summary
- extend `generate_puzzle` with `difficulty` and `seed`
- add `save_puzzle` helper
- update tests for new features

## Testing
- `pip install -r requirements.txt`
- `black .`
- `flake8`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68645a6a5214832c98ef8e64db975cd6