### PR TITLE
マップ保存ファイル名を統一

### DIFF
--- a/MakeGridTraceSPEC.md
+++ b/MakeGridTraceSPEC.md
@@ -42,7 +42,7 @@ def generate_puzzle(rows: int, cols: int, difficulty: str = "normal", *, seed: i
 
 ### 3.2 成果物
 
-- 返値は **dict** —> JSON ダンプして保存（ファイル命名規則 `sl_<行>x<列>_<difficulty>_<timestamp>.json` 推奨）
+- 返値は **dict** —> JSON ダンプして保存（ファイル名は `map_gridtrace.json` に固定）
 - `stdout` へログレベル INFO 以上を出力し、生成状況をレポート（サイズ、難易度、検証統計など）
 
 ---

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ python src/generator.py
    path = generator.save_puzzle(puzzle)
    print(f"{path} を作成しました")
    ```
-2. デフォルトでは `data/` ディレクトリに `sl_<行>x<列>_<difficulty>_<timestamp>.json` の形式で保存されます。
+2. デフォルトでは `data/` ディレクトリに `map_gridtrace.json` という名前で保存されます。
 
 ## 4. JSON フォーマットについて
 

--- a/slitherlink_map_spec_v1.md
+++ b/slitherlink_map_spec_v1.md
@@ -116,9 +116,8 @@
    - すべての数字マスがヒント条件を満たす（0–3）  
 3. **難易度タグ**  
    - 主観で良いが、後から一括変更しやすいよう統一語彙を使用  
-4. **ファイル命名規則**（推奨）  
-   - `sl_<行>x<列>_<difficulty>_<連番>.json`  
-     - 例 : `sl_4x4_easy_001.json`  
+4. **ファイル名**
+  - `map_gridtrace.json` に統一する
 5. **レビュー手順**  
    1. JSON Linter で構文チェック  
    2. 内部ツールで自動パズル検証（ヒント整合 & ループ検証）  
@@ -139,7 +138,7 @@
 ## 8. 参考実装スニペット（抜粋・JavaScript）
 
 ```js
-import puzzleData from './sl_4x4_easy_001.json' assert { type: 'json' };
+import puzzleData from './map_gridtrace.json' assert { type: 'json' };
 
 const { size, clues, solutionEdges } = puzzleData;
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -107,8 +107,9 @@ def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:
     """
     path = Path(directory)
     path.mkdir(parents=True, exist_ok=True)
-    fname = f"{puzzle['id']}.json"
-    file_path = path / fname
+    # 出力ファイル名は常に map_gridtrace.json とする
+    # 複数生成する場合はディレクトリを変えるなどで調整する想定
+    file_path = path / "map_gridtrace.json"
     with file_path.open("w", encoding="utf-8") as fp:
         json.dump(puzzle, fp, ensure_ascii=False, indent=2)
     return file_path

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -26,6 +26,7 @@ def test_save_puzzle(tmp_path: Path) -> None:
     puzzle = generator.generate_puzzle(4, 4, difficulty="easy")
     path = generator.save_puzzle(puzzle, directory=tmp_path)
     assert path.exists()
+    assert path.name == "map_gridtrace.json"
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["id"].startswith("sl_4x4_easy_")
 


### PR DESCRIPTION
## Summary
- save_puzzle の出力先ファイルを `map_gridtrace.json` 固定へ変更
- README と仕様書を修正して新しいファイル名を反映
- テストを更新し保存ファイル名を確認

## Testing
- `black .`
- `flake8`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686461107080832c8947e15303b73e4f