### PR TITLE
Add multi-difficulty batch generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ puzzle = generator.generate_puzzle(4, 4, difficulty="easy")
 python src/generator.py
 ```
 
+### 複数の難易度をまとめて生成する
+
+`bulk_generator.py` を使うと、4 種類の難易度を同数生成して一つの JSON ファイルに保存できます。
+
+```bash
+python src/bulk_generator.py 4 4 2
+```
+
+1 番目と 2 番目の引数は盤面の行数と列数、3 番目の引数は各難易度で何問生成するかを指定します。出力は `data/map_gridtrace.json` に保存されます。
+
 ## 3. マップを保存する
 
 1. `save_puzzle` 関数を使うと、生成したマップを JSON ファイルとして保存できます。

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,17 @@
 """generator モジュールの公開関数をまとめる"""
 
-from .generator import generate_puzzle, save_puzzle, validate_puzzle
+from .generator import (
+    generate_puzzle,
+    save_puzzle,
+    validate_puzzle,
+    generate_multiple_puzzles,
+    save_puzzles,
+)
 
-__all__ = ["generate_puzzle", "save_puzzle", "validate_puzzle"]
+__all__ = [
+    "generate_puzzle",
+    "save_puzzle",
+    "validate_puzzle",
+    "generate_multiple_puzzles",
+    "save_puzzles",
+]

--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -1,0 +1,30 @@
+"""難易度ごとのパズルをまとめて生成するスクリプト"""
+
+from __future__ import annotations
+
+import argparse
+
+from .generator import generate_multiple_puzzles, save_puzzles
+
+
+# コマンドラインから実行される関数
+def main() -> None:
+    """引数を解釈してパズルを生成し保存する"""
+
+    parser = argparse.ArgumentParser(
+        description="easy/normal/hard/expert を同数生成して保存します"
+    )
+    parser.add_argument("rows", type=int, help="盤面の行数")
+    parser.add_argument("cols", type=int, help="盤面の列数")
+    parser.add_argument(
+        "count_each", type=int, default=1, help="各難易度の生成数 (デフォルト:1)"
+    )
+    args = parser.parse_args()
+
+    puzzles = generate_multiple_puzzles(args.rows, args.cols, args.count_each)
+    path = save_puzzles(puzzles)
+    print(f"{path} を作成しました")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/generator.py
+++ b/src/generator.py
@@ -115,6 +115,44 @@ def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:
     return file_path
 
 
+def generate_multiple_puzzles(
+    rows: int, cols: int, count_each: int, *, seed: int | None = None
+) -> List[Puzzle]:
+    """各難易度を同数生成して一覧で返す
+
+    :param rows: 盤面の行数
+    :param cols: 盤面の列数
+    :param count_each: 各難易度の生成数
+    :param seed: 乱数シード。再現したいときに指定する
+    """
+
+    if count_each <= 0:
+        raise ValueError("count_each は 1 以上を指定してください")
+
+    puzzles: List[Puzzle] = []
+    seed_offset = 0
+    # 難易度の順序を固定するためリスト化
+    for difficulty in sorted(ALLOWED_DIFFICULTIES):
+        for _ in range(count_each):
+            puzzle_seed = None if seed is None else seed + seed_offset
+            puzzles.append(
+                generate_puzzle(rows, cols, difficulty=difficulty, seed=puzzle_seed)
+            )
+            seed_offset += 1
+    return puzzles
+
+
+def save_puzzles(puzzles: List[Puzzle], directory: str | Path = "data") -> Path:
+    """複数のパズルをひとつの JSON ファイルに保存する"""
+
+    path = Path(directory)
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / "map_gridtrace.json"
+    with file_path.open("w", encoding="utf-8") as fp:
+        json.dump(puzzles, fp, ensure_ascii=False, indent=2)
+    return file_path
+
+
 def validate_puzzle(puzzle: Puzzle) -> None:
     """パズルデータの整合性を簡易チェックする関数"""
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -43,3 +43,12 @@ def test_validate_puzzle_fail() -> None:
     puzzle["solutionEdges"]["horizontal"][0][0] = False
     with pytest.raises(ValueError):
         generator.validate_puzzle(puzzle)
+
+
+def test_generate_multiple_and_save(tmp_path: Path) -> None:
+    puzzles = generator.generate_multiple_puzzles(3, 3, count_each=1)
+    assert len(puzzles) == 4
+    path = generator.save_puzzles(puzzles, directory=tmp_path)
+    assert path.exists()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert len(data) == 4


### PR DESCRIPTION
## Summary
- add `generate_multiple_puzzles` and `save_puzzles`
- provide CLI script `bulk_generator.py`
- document how to generate multiple puzzles
- export new functions and test them

## Testing
- `black -q .`
- `flake8`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686463eefb70832c8cb998518ab3f06b