### PR TITLE
ASCII 表示機能の追加

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -6,6 +6,7 @@ from .generator import (
     validate_puzzle,
     generate_multiple_puzzles,
     save_puzzles,
+    puzzle_to_ascii,
 )
 
 __all__ = [
@@ -14,4 +15,5 @@ __all__ = [
     "validate_puzzle",
     "generate_multiple_puzzles",
     "save_puzzles",
+    "puzzle_to_ascii",
 ]

--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from .generator import generate_multiple_puzzles, save_puzzles
+from .generator import generate_multiple_puzzles, save_puzzles, puzzle_to_ascii
 
 
 # コマンドラインから実行される関数
@@ -24,6 +24,10 @@ def main() -> None:
     puzzles = generate_multiple_puzzles(args.rows, args.cols, args.count_each)
     path = save_puzzles(puzzles)
     print(f"{path} を作成しました")
+    # 生成した各パズルを ASCII で表示
+    for pzl in puzzles:
+        print(f"--- {pzl['difficulty']} ---")
+        print(puzzle_to_ascii(pzl))
 
 
 if __name__ == "__main__":

--- a/src/generator.py
+++ b/src/generator.py
@@ -254,8 +254,44 @@ def validate_puzzle(puzzle: Puzzle) -> None:
         raise ValueError("clues が solutionEdges と一致しません")
 
 
+def puzzle_to_ascii(puzzle: Puzzle) -> str:
+    """パズル情報から ASCII 形式の盤面を生成して文字列で返す"""
+
+    size_dict = puzzle["size"]
+    size = PuzzleSize(rows=size_dict["rows"], cols=size_dict["cols"])
+    clues: List[List[int]] = puzzle["clues"]
+    edges = puzzle["solutionEdges"]
+    horizontal: List[List[bool]] = edges["horizontal"]
+    vertical: List[List[bool]] = edges["vertical"]
+
+    lines: List[str] = []
+    for r in range(size.rows * 2 + 1):
+        if r % 2 == 0:
+            # 頂点行。水平線を描画する
+            row_idx = r // 2
+            line = ""
+            for c in range(size.cols):
+                line += "+"
+                line += "---" if horizontal[row_idx][c] else "   "
+            line += "+"
+            lines.append(line)
+        else:
+            # 数字行。縦線とヒント数字を描画する
+            row_idx = r // 2
+            line = ""
+            for c in range(size.cols + 1):
+                line += "|" if vertical[row_idx][c] else " "
+                if c < size.cols:
+                    line += f" {clues[row_idx][c]} "
+            lines.append(line)
+
+    return "\n".join(lines)
+
+
 if __name__ == "__main__":
     # 実行例：生成したパズルを保存
     pzl = generate_puzzle(4, 4, difficulty="easy")
     path = save_puzzle(pzl)
     print(f"{path} を作成しました")
+    # 生成した盤面を ASCII で表示
+    print(puzzle_to_ascii(pzl))

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -52,3 +52,14 @@ def test_generate_multiple_and_save(tmp_path: Path) -> None:
     assert path.exists()
     data = json.loads(path.read_text(encoding="utf-8"))
     assert len(data) == 4
+
+
+def test_puzzle_to_ascii() -> None:
+    puzzle = generator.generate_puzzle(2, 2, difficulty="easy")
+    ascii_art = generator.puzzle_to_ascii(puzzle)
+    assert isinstance(ascii_art, str)
+    lines = ascii_art.splitlines()
+    # 2x2 の場合は行数が 5 になるはず
+    assert len(lines) == 5
+    # 1 行目には "+" 記号が含まれる
+    assert "+" in lines[0]


### PR DESCRIPTION
## Summary
- パズルを文字で見られる `puzzle_to_ascii` を実装
- generator.py と bulk_generator.py 実行時に ASCII 表示
- 共有関数として `puzzle_to_ascii` を公開
- 新しいテスト `test_puzzle_to_ascii` を追加

## Testing
- `black -q src tests`
- `flake8`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686465cbe240832cbbee0116befb65c6