### PR TITLE
Add symmetry option and CLI parameters

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -85,3 +85,8 @@ def test_puzzle_to_ascii() -> None:
     assert len(lines) == 5
     # 1 行目には "+" 記号が含まれる
     assert "+" in lines[0]
+
+
+def test_generate_puzzle_symmetry() -> None:
+    puzzle = generator.generate_puzzle(4, 4, symmetry="rotational")
+    assert puzzle["symmetry"] == "rotational"


### PR DESCRIPTION
## Summary
- implement `generate_puzzle` symmetry argument
- provide command line interface for generator
- include simple symmetry test
- update typing for `mypy`

## Testing
- `black -q src tests`
- `flake8`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686480bf7fc8832cbcaca8433141da6a