### PR TITLE
Add cluesFull for puzzle generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ python -m src.bulk_generator 4 4 2
 
 - `id` : マップを一意に識別する文字列
 - `size` : 盤面の行数と列数を表すオブジェクト
-- `clues` : 各セルのヒント数字を 2 次元配列で保持（空白マスは `null`）
+- `clues` : 出題用ヒント。空白マスは `null`
+- `cluesFull` : すべてのセルに数値が入った解答用ヒント
 - `solutionEdges` : 正解ループの情報。水平線と垂直線の配列をまとめたもの
 - `difficulty` : 難易度ラベル
 

--- a/slitherlink_map_spec_v1.md
+++ b/slitherlink_map_spec_v1.md
@@ -17,7 +17,8 @@
 |------|----|------|------|
 | `id` | string | ✔ | 一意な問題 ID。ファイル名や URL に使用可 |
 | `size` | object | ✔ | 盤面サイズ `{ "rows": <int>, "cols": <int> }` |
-| `clues` | array[][] | ✔ | セルヒント (0–3) または `null`<br>サイズ = `rows × cols` |
+| `clues` | array[][] | ✔ | 出題用ヒント (0–3) または `null`<br>サイズ = `rows × cols` |
+| `cluesFull` | array[][] | ✔ | 全てのセルに数値が入った解答用ヒント | 
 | `solutionEdges` | object | ✔ | 正解ループの辺情報（後述） |
 | `difficulty` | string | 推奨 | `"easy"`, `"normal"`, `"hard"`, `"expert"` など |
 | `createdBy` | string | 任意 | 作成者名 |
@@ -26,9 +27,14 @@
 ---
 
 ## 3. `clues` フィールド
-- 盤面セルごとのヒント数字を 2 次元配列で保持  
-- **空白マス**は `null`  
+- 出題用のヒント数字を 2 次元配列で保持します
+- **空白マス**は `null`
 - 行と列は **0 インデックス**（配列の行順・列順がそのまま盤面に対応）
+
+### `cluesFull` との違い
+`cluesFull` にはすべてのセルに数値が入った解答用ヒントを記録します。`clues` はそ
+れを削減した出題データで、`null` のセルがあってもかまいません。アプリは `clues`
+を表示し、内部的には `cluesFull` を使って正解判定を行います。
 
 ```jsonc
 "clues": [

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -14,12 +14,17 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
     data = json.dumps(puzzle)
     assert "clues" in puzzle
     assert "solutionEdges" in puzzle
+    assert "cluesFull" in puzzle
     assert puzzle["schemaVersion"] == "2.0"
     assert "loopStats" in puzzle
     assert puzzle["loopStats"]["curveRatio"] >= 0.15
     assert "solverStats" in puzzle
     assert puzzle["solverStats"]["steps"] >= 0
     assert puzzle["solverStats"]["maxDepth"] >= 0
+    calc = generator._calculate_clues(
+        puzzle["solutionEdges"], generator.PuzzleSize(4, 4)
+    )
+    assert puzzle["cluesFull"] == calc
     # 一時ファイルに保存し読み込んでみる
     file = tmp_path / "puzzle.json"
     file.write_text(data, encoding="utf-8")
@@ -65,8 +70,8 @@ def test_validate_puzzle_fail() -> None:
 def test_zero_adjacent_fail() -> None:
     puzzle = generator.generate_puzzle(3, 3, difficulty="easy", seed=4)
     # 0 を縦に並べて検証エラーを期待
-    puzzle["clues"][0][0] = 0
-    puzzle["clues"][1][0] = 0
+    puzzle["cluesFull"][0][0] = 0
+    puzzle["cluesFull"][1][0] = 0
     with pytest.raises(ValueError):
         generator.validate_puzzle(puzzle)
 


### PR DESCRIPTION
## Summary
- enhance Slitherlink JSON format to include `cluesFull`
- output both puzzle clues and full clues when generating puzzles
- update validation logic for new field
- adjust README and tests for the new schema

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864896cf940832cafaee4393f7bdf79