### PR TITLE
Add parallel puzzle generation

### DIFF
--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -99,3 +99,8 @@ def test_puzzle_to_ascii() -> None:
 def test_generate_puzzle_symmetry() -> None:
     puzzle = generator.generate_puzzle(4, 4, symmetry="rotational", seed=7)
     assert puzzle["symmetry"] == "rotational"
+
+
+def test_generate_puzzle_parallel() -> None:
+    puzzle = generator.generate_puzzle_parallel(3, 3, seed=8, jobs=2)
+    generator.validate_puzzle(puzzle)


### PR DESCRIPTION
## Summary
- add `generate_puzzle_parallel` using multiple processes
- enable `--parallel` option in the command line
- test the parallel generator

## Testing
- `flake8`
- `mypy src`
- `black --check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68648f6dfe6c832c900e2490cc2a7510