### PR TITLE
Fix ASCII grid alignment for None clues

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -726,7 +726,10 @@ def puzzle_to_ascii(puzzle: Puzzle) -> str:
             for c in range(size.cols + 1):
                 line += "|" if vertical[row_idx][c] else " "
                 if c < size.cols:
-                    line += f" {clues[row_idx][c]} "
+                    value = clues[row_idx][c]
+                    # None のまま表示すると幅が広がるので 'N' で代用
+                    cell = "N" if value is None else str(value)
+                    line += f" {cell} "
             lines.append(line)
 
     return "\n".join(lines)


### PR DESCRIPTION
## Summary
- puzzle_to_ascii で `None` を表示する際に `N` に置き換えて幅を揃える

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649d8ebb28832cbbd23e19be0b9e71