### PR TITLE
Fix generator script import

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -12,7 +12,12 @@ import random
 import concurrent.futures
 from typing import Any, Dict, List, Optional, cast
 
-from .solver import PuzzleSize, calculate_clues, count_solutions
+try:
+    # パッケージとして実行された場合の相対インポート
+    from .solver import PuzzleSize, calculate_clues, count_solutions
+except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+    # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+    from solver import PuzzleSize, calculate_clues, count_solutions
 
 
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- fall back to absolute imports when running `src/generator.py` directly

## Testing
- `black src/generator.py`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a094ce88832cb4ae163d35f0e987