### PR TITLE
モジュール分割とテスト修正

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,12 +2,11 @@
 
 from .generator import (
     generate_puzzle,
-    save_puzzle,
-    validate_puzzle,
     generate_multiple_puzzles,
-    save_puzzles,
     puzzle_to_ascii,
 )
+from .puzzle_io import save_puzzle, save_puzzles
+from .validator import validate_puzzle
 
 __all__ = [
     "generate_puzzle",

--- a/src/loop_builder.py
+++ b/src/loop_builder.py
@@ -1,0 +1,160 @@
+"""ループ生成に関する補助関数をまとめたモジュール"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import random
+
+from .solver import PuzzleSize
+
+
+def _create_empty_edges(size: PuzzleSize) -> Dict[str, List[List[bool]]]:
+    """solutionEdges 用の空の二次元配列を作成する"""
+    horizontal = [[False for _ in range(size.cols)] for _ in range(size.rows + 1)]
+    vertical = [[False for _ in range(size.cols + 1)] for _ in range(size.rows)]
+    return {"horizontal": horizontal, "vertical": vertical}
+
+
+def _generate_random_loop(edges: Dict[str, List[List[bool]]], size: PuzzleSize) -> None:
+    """バックトラックでランダムなループを生成する"""
+
+    degrees = [[0 for _ in range(size.cols + 1)] for _ in range(size.rows + 1)]
+
+    def edge_exists(a: tuple[int, int], b: tuple[int, int]) -> bool:
+        """2 点間の辺が存在するか確認"""
+        if a[0] == b[0]:
+            r = a[0]
+            c = min(a[1], b[1])
+            return edges["horizontal"][r][c]
+        else:
+            c = a[1]
+            r = min(a[0], b[0])
+            return edges["vertical"][r][c]
+
+    def add_edge(a: tuple[int, int], b: tuple[int, int]) -> None:
+        """2 点を結ぶ辺を追加する"""
+        if a[0] == b[0]:
+            r = a[0]
+            c = min(a[1], b[1])
+            edges["horizontal"][r][c] = True
+        else:
+            c = a[1]
+            r = min(a[0], b[0])
+            edges["vertical"][r][c] = True
+        degrees[a[0]][a[1]] += 1
+        degrees[b[0]][b[1]] += 1
+
+    def remove_edge(a: tuple[int, int], b: tuple[int, int]) -> None:
+        """2 点を結ぶ辺を削除する"""
+        if a[0] == b[0]:
+            r = a[0]
+            c = min(a[1], b[1])
+            edges["horizontal"][r][c] = False
+        else:
+            c = a[1]
+            r = min(a[0], b[0])
+            edges["vertical"][r][c] = False
+        degrees[a[0]][a[1]] -= 1
+        degrees[b[0]][b[1]] -= 1
+
+    min_len = max(2 * (size.rows + size.cols), 4)
+
+    start = (random.randint(0, size.rows), random.randint(0, size.cols))
+    path: list[tuple[int, int]] = [start]
+
+    def dfs(current: tuple[int, int]) -> bool:
+        if len(path) >= min_len and current == start and len(path) > 1:
+            return True
+        directions = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        random.shuffle(directions)
+        for dr, dc in directions:
+            nr, nc = current[0] + dr, current[1] + dc
+            if not (0 <= nr <= size.rows and 0 <= nc <= size.cols):
+                continue
+            nxt = (nr, nc)
+            if degrees[nr][nc] >= 2 or degrees[current[0]][current[1]] >= 2:
+                continue
+            if edge_exists(current, nxt):
+                continue
+            if nxt == start and len(path) + 1 < min_len:
+                continue
+            add_edge(current, nxt)
+            path.append(nxt)
+            if dfs(nxt):
+                return True
+            path.pop()
+            remove_edge(current, nxt)
+        return False
+
+    if not dfs(start):
+        # 失敗したら外周ループを生成
+        for c in range(size.cols):
+            edges["horizontal"][0][c] = True
+            edges["horizontal"][size.rows][c] = True
+        for r in range(size.rows):
+            edges["vertical"][r][0] = True
+            edges["vertical"][r][size.cols] = True
+
+
+def _apply_rotational_symmetry(
+    edges: Dict[str, List[List[bool]]], size: PuzzleSize
+) -> None:
+    """180 度回転対称になるよう辺情報を補正"""
+    horizontal = edges["horizontal"]
+    for r in range(size.rows + 1):
+        for c in range(size.cols):
+            sr = size.rows - r
+            sc = size.cols - c - 1
+            val = horizontal[r][c] or horizontal[sr][sc]
+            horizontal[r][c] = val
+            horizontal[sr][sc] = val
+    vertical = edges["vertical"]
+    for r in range(size.rows):
+        for c in range(size.cols + 1):
+            sr = size.rows - r - 1
+            sc = size.cols - c
+            val = vertical[r][c] or vertical[sr][sc]
+            vertical[r][c] = val
+            vertical[sr][sc] = val
+
+
+def _count_edges(edges: Dict[str, List[List[bool]]]) -> int:
+    """True の数を数えてループ長を求める"""
+    return sum(sum(row) for row in edges["horizontal"]) + sum(
+        sum(row) for row in edges["vertical"]
+    )
+
+
+def _calculate_curve_ratio(
+    edges: Dict[str, List[List[bool]]], size: PuzzleSize
+) -> float:
+    """ループ中の曲がり角割合を計算"""
+    curve_count = 0
+    for r in range(size.rows + 1):
+        for c in range(size.cols + 1):
+            connections = []
+            if c < size.cols and edges["horizontal"][r][c]:
+                connections.append("h")
+            if c > 0 and edges["horizontal"][r][c - 1]:
+                connections.append("h")
+            if r < size.rows and edges["vertical"][r][c]:
+                connections.append("v")
+            if r > 0 and edges["vertical"][r - 1][c]:
+                connections.append("v")
+            if (
+                len(connections) == 2
+                and connections.count("h") == 1
+                and connections.count("v") == 1
+            ):
+                curve_count += 1
+    total = _count_edges(edges)
+    return curve_count / total if total > 0 else 0.0
+
+
+__all__ = [
+    "_create_empty_edges",
+    "_generate_random_loop",
+    "_apply_rotational_symmetry",
+    "_count_edges",
+    "_calculate_curve_ratio",
+]

--- a/src/puzzle_io.py
+++ b/src/puzzle_io.py
@@ -1,0 +1,33 @@
+"""パズルを保存・読み込みする処理をまとめたモジュール"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict, Any
+
+# generator への循環参照を避けるため型エイリアスだけ定義
+Puzzle = Dict[str, Any]
+
+
+def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:
+    """単一のパズルを JSON 形式で保存する"""
+    path = Path(directory)
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / "map_gridtrace.json"
+    with file_path.open("w", encoding="utf-8") as fp:
+        json.dump(puzzle, fp, ensure_ascii=False, indent=2)
+    return file_path
+
+
+def save_puzzles(puzzles: List[Puzzle], directory: str | Path = "data") -> Path:
+    """複数パズルをまとめて JSON 保存する"""
+    path = Path(directory)
+    path.mkdir(parents=True, exist_ok=True)
+    file_path = path / "map_gridtrace.json"
+    with file_path.open("w", encoding="utf-8") as fp:
+        json.dump(puzzles, fp, ensure_ascii=False, indent=2)
+    return file_path
+
+
+__all__ = ["save_puzzle", "save_puzzles"]

--- a/src/validator.py
+++ b/src/validator.py
@@ -1,0 +1,128 @@
+"""パズルデータの整合性を確認するモジュール"""
+
+from __future__ import annotations
+
+
+from .solver import PuzzleSize, calculate_clues
+from .loop_builder import _calculate_curve_ratio
+from typing import Any, Dict
+
+# generator との循環参照を避けるため型エイリアスのみ定義
+Puzzle = Dict[str, Any]
+
+
+def validate_puzzle(puzzle: Puzzle) -> None:
+    """盤面データが仕様を満たすか簡易チェックする"""
+
+    size_dict = puzzle.get("size")
+    if not isinstance(size_dict, dict):
+        raise ValueError("size フィールドが存在しません")
+    size = PuzzleSize(rows=size_dict["rows"], cols=size_dict["cols"])
+
+    edges = puzzle.get("solutionEdges")
+    if not isinstance(edges, dict):
+        raise ValueError("solutionEdges フィールドが存在しません")
+    horizontal = edges.get("horizontal")
+    vertical = edges.get("vertical")
+    if (
+        not isinstance(horizontal, list)
+        or not isinstance(vertical, list)
+        or len(horizontal) != size.rows + 1
+        or len(vertical) != size.rows
+    ):
+        raise ValueError("solutionEdges のサイズが盤面サイズと一致しません")
+    for row in horizontal:
+        if len(row) != size.cols:
+            raise ValueError("horizontal 配列の列数が不正です")
+    for row in vertical:
+        if len(row) != size.cols + 1:
+            raise ValueError("vertical 配列の列数が不正です")
+
+    edge_count = 0
+    degrees = [[0 for _ in range(size.cols + 1)] for _ in range(size.rows + 1)]
+    for r in range(size.rows + 1):
+        for c in range(size.cols):
+            if horizontal[r][c]:
+                edge_count += 1
+                degrees[r][c] += 1
+                degrees[r][c + 1] += 1
+    for r in range(size.rows):
+        for c in range(size.cols + 1):
+            if vertical[r][c]:
+                edge_count += 1
+                degrees[r][c] += 1
+                degrees[r + 1][c] += 1
+
+    start = None
+    for r in range(size.rows + 1):
+        for c in range(size.cols + 1):
+            d = degrees[r][c]
+            if d not in (0, 2):
+                raise ValueError("ループが分岐または交差しています")
+            if d == 2 and start is None:
+                start = (r, c)
+    if start is None:
+        raise ValueError("ループが存在しません")
+
+    visited_edges: set[tuple[tuple[int, int], tuple[int, int]]] = set()
+    queue = [start]
+    visited_vertices = {start}
+
+    def neighbors(r: int, c: int) -> list[tuple[int, int]]:
+        result = []
+        if c < size.cols and horizontal[r][c]:
+            result.append((r, c + 1))
+        if c > 0 and horizontal[r][c - 1]:
+            result.append((r, c - 1))
+        if r < size.rows and vertical[r][c]:
+            result.append((r + 1, c))
+        if r > 0 and vertical[r - 1][c]:
+            result.append((r - 1, c))
+        return result
+
+    while queue:
+        r, c = queue.pop(0)
+        for nr, nc in neighbors(r, c):
+            edge = ((r, c), (nr, nc)) if (r, c) <= (nr, nc) else ((nr, nc), (r, c))
+            if edge not in visited_edges:
+                visited_edges.add(edge)
+                if (nr, nc) not in visited_vertices:
+                    visited_vertices.add((nr, nc))
+                    queue.append((nr, nc))
+
+    if len(visited_edges) != edge_count:
+        raise ValueError("ループが複数存在する可能性があります")
+
+    if edge_count < 2 * (size.rows + size.cols):
+        raise ValueError("ループ長がハード制約を満たしていません")
+
+    clues_full = puzzle.get("cluesFull")
+    if not isinstance(clues_full, list):
+        raise ValueError("cluesFull フィールドが存在しません")
+    calculated = calculate_clues(edges, size)
+    if clues_full != calculated:
+        raise ValueError("cluesFull が solutionEdges と一致しません")
+
+    clues = puzzle.get("clues")
+    if not isinstance(clues, list):
+        raise ValueError("clues フィールドが存在しません")
+    for r in range(size.rows):
+        for c in range(size.cols):
+            val = clues[r][c]
+            if val is not None and val != clues_full[r][c]:
+                raise ValueError("clues が cluesFull と一致しません")
+
+    for r in range(size.rows):
+        for c in range(size.cols):
+            if clues_full[r][c] == 0:
+                if r + 1 < size.rows and clues_full[r + 1][c] == 0:
+                    raise ValueError("0 が縦に隣接しています")
+                if c + 1 < size.cols and clues_full[r][c + 1] == 0:
+                    raise ValueError("0 が横に隣接しています")
+
+    curve_ratio = _calculate_curve_ratio(edges, size)
+    if curve_ratio < 0.15:
+        raise ValueError("線カーブ比率がハード制約を満たしていません")
+
+
+__all__ = ["validate_puzzle"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -6,6 +6,8 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(ROOT))
 from src import generator  # noqa: E402
+from src import puzzle_io  # noqa: E402
+from src import validator  # noqa: E402
 from src import solver  # noqa: E402
 
 
@@ -34,7 +36,7 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
 
 def test_save_puzzle(tmp_path: Path) -> None:
     puzzle = generator.generate_puzzle(4, 4, difficulty="easy", seed=1)
-    path = generator.save_puzzle(puzzle, directory=tmp_path)
+    path = puzzle_io.save_puzzle(puzzle, directory=tmp_path)
     assert path.exists()
     assert path.name == "map_gridtrace.json"
     data = json.loads(path.read_text(encoding="utf-8"))
@@ -45,7 +47,7 @@ def test_save_puzzle(tmp_path: Path) -> None:
 def test_validate_puzzle() -> None:
     puzzle = generator.generate_puzzle(4, 4, seed=0)
     # エラーが出ないことを確認
-    generator.validate_puzzle(puzzle)
+    validator.validate_puzzle(puzzle)
 
 
 def test_validate_puzzle_fail() -> None:
@@ -63,7 +65,7 @@ def test_validate_puzzle_fail() -> None:
     if not broken:
         puzzle["solutionEdges"]["vertical"][0][0] = False
     with pytest.raises(ValueError):
-        generator.validate_puzzle(puzzle)
+        validator.validate_puzzle(puzzle)
 
 
 def test_zero_adjacent_fail() -> None:
@@ -72,13 +74,13 @@ def test_zero_adjacent_fail() -> None:
     puzzle["cluesFull"][0][0] = 0
     puzzle["cluesFull"][1][0] = 0
     with pytest.raises(ValueError):
-        generator.validate_puzzle(puzzle)
+        validator.validate_puzzle(puzzle)
 
 
 def test_generate_multiple_and_save(tmp_path: Path) -> None:
     puzzles = generator.generate_multiple_puzzles(3, 3, count_each=1, seed=5)
     assert len(puzzles) == 4
-    path = generator.save_puzzles(puzzles, directory=tmp_path)
+    path = puzzle_io.save_puzzles(puzzles, directory=tmp_path)
     assert path.exists()
     data = json.loads(path.read_text(encoding="utf-8"))
     assert len(data) == 4
@@ -102,7 +104,7 @@ def test_generate_puzzle_symmetry() -> None:
 
 def test_generate_puzzle_parallel() -> None:
     puzzle = generator.generate_puzzle_parallel(3, 3, seed=8, jobs=2)
-    generator.validate_puzzle(puzzle)
+    validator.validate_puzzle(puzzle)
 
 
 def test_count_solutions_unique() -> None:


### PR DESCRIPTION
## Summary
- ループ処理、入出力、検証処理を個別モジュールに分離
- generator.py の重複コード整理とインポート更新
- src/__init__ を新構成に対応
- テストを新モジュール利用に書き換え

## Testing
- `black -q src tests`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a2204e14832c86b337160ff87786