### PR TITLE
型エイリアス Puzzle の共通化

### DIFF
--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import argparse
 
-from .generator import generate_multiple_puzzles, save_puzzles, puzzle_to_ascii
+from .generator import generate_multiple_puzzles, puzzle_to_ascii
+from .puzzle_io import save_puzzles
 
 
 # コマンドラインから実行される関数

--- a/src/generator.py
+++ b/src/generator.py
@@ -11,6 +11,8 @@ import concurrent.futures
 import hashlib
 from typing import Any, Dict, List, Optional, cast, TYPE_CHECKING
 
+from .types import Puzzle
+
 if TYPE_CHECKING:
     from src.solver import PuzzleSize, calculate_clues, count_solutions
 else:
@@ -41,8 +43,6 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-
-Puzzle = Dict[str, Any]
 
 # JSON スキーマのバージョン
 SCHEMA_VERSION = "2.0"

--- a/src/puzzle_io.py
+++ b/src/puzzle_io.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List
 
-# generator への循環参照を避けるため型エイリアスだけ定義
-Puzzle = Dict[str, Any]
+from .types import Puzzle
 
 
 def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:

--- a/src/types.py
+++ b/src/types.py
@@ -1,0 +1,8 @@
+"""共通で使用する型エイリアスを定義するモジュール"""
+
+from typing import Any, Dict
+
+# Puzzle は文字列キーを持つ辞書型とする
+Puzzle = Dict[str, Any]
+
+__all__ = ["Puzzle"]

--- a/src/validator.py
+++ b/src/validator.py
@@ -5,10 +5,7 @@ from __future__ import annotations
 
 from .solver import PuzzleSize, calculate_clues
 from .loop_builder import _calculate_curve_ratio
-from typing import Any, Dict
-
-# generator との循環参照を避けるため型エイリアスのみ定義
-Puzzle = Dict[str, Any]
+from .types import Puzzle
 
 
 def validate_puzzle(puzzle: Puzzle) -> None:


### PR DESCRIPTION
## Summary
- add `types.py` to keep common type alias `Puzzle`
- refactor modules to import `Puzzle` from the new module
- fix bulk_generator import

## Testing
- `flake8`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864a7be2364832c92e9ed7052bc48ce