### PR TITLE
Move puzzle helpers

### DIFF
--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import argparse
 
-from .generator import generate_multiple_puzzles, save_puzzles, puzzle_to_ascii
+from .generator import generate_multiple_puzzles, puzzle_to_ascii
+from .puzzle_io import save_puzzles
 
 
 # コマンドラインから実行される関数

--- a/src/generator.py
+++ b/src/generator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from datetime import datetime
 import logging
 import time
 import os
@@ -33,6 +32,7 @@ from .loop_builder import (
 )
 from .puzzle_io import save_puzzle
 from .validator import validate_puzzle
+from .puzzle_builder import _build_puzzle_dict, _reduce_clues
 
 
 logging.basicConfig(
@@ -66,84 +66,6 @@ RETRY_LIMIT = 5
 # ソルバーが探索する最大ステップ数。超えると途中で打ち切る
 # ソルバーのステップ上限を増加させて解の探索精度を向上させる
 MAX_SOLVER_STEPS = 500000
-
-
-def _evaluate_difficulty(steps: int, depth: int) -> str:
-    """ソルバー統計から難易度を推定する関数"""
-
-    # 解析ステップ数とバックトラック深さを基準に難易度を決める
-    if steps < 1000 and depth <= 2:
-        return "easy"
-    if steps < 10000 and depth <= 10:
-        return "normal"
-    if steps < 100000 and depth <= 30:
-        return "hard"
-    return "expert"
-
-
-def _reduce_clues(
-    clues: List[List[int]], size: PuzzleSize, *, min_hint: int
-) -> List[List[int | None]]:
-    """ヒントをランダムに削減して一意性を保つ"""
-    result: List[List[int | None]] = [[v for v in row] for row in clues]
-    cells = [(r, c) for r in range(size.rows) for c in range(size.cols)]
-    random.shuffle(cells)
-
-    for r, c in cells:
-        if result[r][c] is None:
-            continue
-        original = result[r][c]
-        result[r][c] = None
-        hint_count = sum(1 for row in result for v in row if v is not None)
-        if (
-            hint_count < min_hint
-            or count_solutions(result, size, limit=2, step_limit=MAX_SOLVER_STEPS) != 1
-        ):
-            result[r][c] = original
-
-    return result
-
-
-def _build_puzzle_dict(
-    *,
-    size: PuzzleSize,
-    edges: Dict[str, List[List[bool]]],
-    clues: List[List[int | None]],
-    clues_full: List[List[int]],
-    loop_length: int,
-    curve_ratio: float,
-    difficulty: str,
-    solver_stats: Dict[str, int],
-    symmetry: Optional[str],
-    generation_params: Dict[str, Any],
-    seed_hash: str,
-) -> Puzzle:
-    """パズル用の辞書オブジェクトを構築するヘルパー関数"""
-
-    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
-    puzzle: Puzzle = {
-        "schemaVersion": SCHEMA_VERSION,
-        "id": f"sl_{size.rows}x{size.cols}_{difficulty}_{timestamp}",
-        "size": {"rows": size.rows, "cols": size.cols},
-        "clues": clues,
-        "cluesFull": clues_full,
-        "solutionEdges": edges,
-        "loopStats": {"length": loop_length, "curveRatio": curve_ratio},
-        "solverStats": {
-            "steps": solver_stats["steps"],
-            "maxDepth": solver_stats["max_depth"],
-        },
-        "difficulty": difficulty,
-        "difficultyEval": _evaluate_difficulty(
-            solver_stats["steps"], solver_stats["max_depth"]
-        ),
-        "symmetry": symmetry,
-        "generationParams": generation_params,
-        "seedHash": seed_hash,
-        "createdBy": "auto-gen-v1",
-        "createdAt": datetime.utcnow().date().isoformat(),
-    }
-    return puzzle
 
 
 def generate_puzzle(

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -1,0 +1,94 @@
+"""パズル生成補助関数をまとめたモジュール"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import random
+from typing import Any, Dict, List, Optional
+
+from .solver import PuzzleSize, count_solutions
+
+# generator との循環参照を避けるため型エイリアスをここでも定義
+Puzzle = Dict[str, Any]
+
+MAX_SOLVER_STEPS = 500000
+
+
+def _reduce_clues(
+    clues: List[List[int]], size: PuzzleSize, *, min_hint: int
+) -> List[List[int | None]]:
+    """ヒントをランダムに削減して一意性を保つ"""
+    result: List[List[int | None]] = [[v for v in row] for row in clues]
+    cells = [(r, c) for r in range(size.rows) for c in range(size.cols)]
+    random.shuffle(cells)
+
+    for r, c in cells:
+        if result[r][c] is None:
+            continue
+        original = result[r][c]
+        result[r][c] = None
+        hint_count = sum(1 for row in result for v in row if v is not None)
+        if (
+            hint_count < min_hint
+            or count_solutions(result, size, limit=2, step_limit=MAX_SOLVER_STEPS) != 1
+        ):
+            result[r][c] = original
+
+    return result
+
+
+def _build_puzzle_dict(
+    *,
+    size: PuzzleSize,
+    edges: Dict[str, List[List[bool]]],
+    clues: List[List[int | None]],
+    clues_full: List[List[int]],
+    loop_length: int,
+    curve_ratio: float,
+    difficulty: str,
+    solver_stats: Dict[str, int],
+    symmetry: Optional[str],
+    generation_params: Dict[str, Any],
+    seed_hash: str,
+) -> Puzzle:
+    """パズル用の辞書オブジェクトを構築するヘルパー関数"""
+
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    puzzle: Puzzle = {
+        "schemaVersion": "2.0",
+        "id": f"sl_{size.rows}x{size.cols}_{difficulty}_{timestamp}",
+        "size": {"rows": size.rows, "cols": size.cols},
+        "clues": clues,
+        "cluesFull": clues_full,
+        "solutionEdges": edges,
+        "loopStats": {"length": loop_length, "curveRatio": curve_ratio},
+        "solverStats": {
+            "steps": solver_stats["steps"],
+            "maxDepth": solver_stats["max_depth"],
+        },
+        "difficulty": difficulty,
+        "difficultyEval": _evaluate_difficulty(
+            solver_stats["steps"], solver_stats["max_depth"]
+        ),
+        "symmetry": symmetry,
+        "generationParams": generation_params,
+        "seedHash": seed_hash,
+        "createdBy": "auto-gen-v1",
+        "createdAt": datetime.utcnow().date().isoformat(),
+    }
+    return puzzle
+
+
+def _evaluate_difficulty(steps: int, depth: int) -> str:
+    """ソルバー統計から難易度を推定する関数"""
+
+    if steps < 1000 and depth <= 2:
+        return "easy"
+    if steps < 10000 and depth <= 10:
+        return "normal"
+    if steps < 100000 and depth <= 30:
+        return "hard"
+    return "expert"
+
+
+__all__ = ["_reduce_clues", "_build_puzzle_dict", "_evaluate_difficulty"]


### PR DESCRIPTION
## Summary
- create `puzzle_builder` module to hold helper functions
- simplify `generator` by importing new helpers
- adjust `bulk_generator` imports

## Testing
- `black -q src tests`
- `flake8 src tests`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864a7deeee8832c8940249ca9b98cb0