### PR TITLE
型エイリアス Puzzle を共通化

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -30,9 +30,11 @@ from .loop_builder import (
     _generate_random_loop,
     _count_edges,
     _calculate_curve_ratio,
+    _apply_rotational_symmetry,
 )
 from .puzzle_io import save_puzzle
 from .validator import validate_puzzle, _has_zero_adjacent
+from .types import Puzzle
 
 
 logging.basicConfig(
@@ -40,9 +42,6 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
 )
 logger = logging.getLogger(__name__)
-
-
-Puzzle = Dict[str, Any]
 
 # JSON スキーマのバージョン
 SCHEMA_VERSION = "2.0"

--- a/src/puzzle_io.py
+++ b/src/puzzle_io.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import List
 
-# generator への循環参照を避けるため型エイリアスだけ定義
-Puzzle = Dict[str, Any]
+from .types import Puzzle
 
 
 def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:

--- a/src/types.py
+++ b/src/types.py
@@ -1,0 +1,8 @@
+"""共通で使う型エイリアスをまとめたモジュール"""
+
+from typing import Any, Dict
+
+# Puzzle データを表す辞書型。キーは文字列で値は任意の型を許容
+Puzzle = Dict[str, Any]
+
+__all__ = ["Puzzle"]

--- a/src/validator.py
+++ b/src/validator.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 
 from .solver import PuzzleSize, calculate_clues
 from .loop_builder import _calculate_curve_ratio
-from typing import Any, Dict, List
+from typing import List
 
-# generator との循環参照を避けるため型エイリアスのみ定義
-Puzzle = Dict[str, Any]
+from .types import Puzzle
 
 
 def _has_zero_adjacent(clues: List[List[int]]) -> bool:


### PR DESCRIPTION
## Summary
- `src/types.py` を新規追加して Puzzle 型を定義
- 各モジュールで `from .types import Puzzle` を利用
- `generator` のインポートに `_apply_rotational_symmetry` を追加
- flake8 と mypy を実行しエラーなしを確認
- pytest も実行し全テスト成功

## Testing
- `flake8`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864aa1727b4832c95bdfcebadaf3a42