### PR TITLE
Add slow test marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ python -m src.bulk_generator 4 4 2
 ```bash
 pytest
 ```
+時間の掛かるテストを除外して素早く確認したい場合は、以下のように `-m "not slow"` を付けます。
+```bash
+pytest -m "not slow"
+```
 
 ## 6. 参考資料
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --maxfail=1
+markers =
+    slow: 長時間実行されるテスト

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -98,6 +98,7 @@ def test_generator_zero_not_adjacent() -> None:
     assert not validator._has_zero_adjacent(puzzle["cluesFull"])
 
 
+@pytest.mark.slow
 def test_generate_multiple_and_save(tmp_path: Path) -> None:
     puzzles = generator.generate_multiple_puzzles(3, 3, count_each=1, seed=5)
     assert len(puzzles) == 4
@@ -118,11 +119,13 @@ def test_puzzle_to_ascii() -> None:
     assert "+" in lines[0]
 
 
+@pytest.mark.slow
 def test_generate_puzzle_symmetry() -> None:
     puzzle = generator.generate_puzzle(4, 4, symmetry="rotational", seed=7)
     assert puzzle["symmetry"] == "rotational"
 
 
+@pytest.mark.slow
 def test_solution_edges_rotational() -> None:
     puzzle = generator.generate_puzzle(4, 4, symmetry="rotational", seed=42)
     edges = puzzle["solutionEdges"]
@@ -145,11 +148,13 @@ def test_solution_edges_rotational() -> None:
             assert vertical[r][c] == vertical[sr][sc]
 
 
+@pytest.mark.slow
 def test_generate_puzzle_parallel() -> None:
     puzzle = generator.generate_puzzle_parallel(3, 3, seed=8, jobs=2)
     validator.validate_puzzle(puzzle)
 
 
+@pytest.mark.slow
 def test_generation_params_and_seedhash() -> None:
     puzzle = generator.generate_puzzle(
         3, 3, difficulty="normal", seed=42, symmetry="rotational"
@@ -165,6 +170,7 @@ def test_generation_params_and_seedhash() -> None:
     assert puzzle["seedHash"] == hashlib.sha256(b"42").hexdigest()
 
 
+@pytest.mark.slow
 def test_count_solutions_unique() -> None:
     puzzle = generator.generate_puzzle(3, 3, seed=9)
     size = solver.PuzzleSize(3, 3)


### PR DESCRIPTION
## Summary
- add slow markers to time-consuming tests
- configure pytest.ini for slow marks and limit failures
- document quick test run in README

## Testing
- `flake8`
- `pytest -m "not slow" -vv --maxfail=1`

------
https://chatgpt.com/codex/tasks/task_e_6864aa080c84832c8f4d7e319d670f93