### PR TITLE
Add configurable logging setup

### DIFF
--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 
-from .generator import generate_multiple_puzzles, puzzle_to_ascii
+from .generator import generate_multiple_puzzles, puzzle_to_ascii, setup_logging
 from .puzzle_io import save_puzzles
 
 
@@ -32,4 +32,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    # ログ設定を行ってからメイン処理を呼び出す
+    setup_logging()
     main()

--- a/src/generator.py
+++ b/src/generator.py
@@ -38,11 +38,13 @@ from .puzzle_builder import _build_puzzle_dict, _reduce_clues
 from .types import Puzzle
 
 
+def setup_logging(level: int = logging.INFO) -> None:
+    """logging を設定する関数"""
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
+    # ログはプログラムの動作を記録する仕組みです
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(message)s")
+
+
 logger = logging.getLogger(__name__)
 
 # JSON スキーマのバージョン
@@ -389,6 +391,9 @@ def puzzle_to_ascii(puzzle: Puzzle) -> str:
 
 if __name__ == "__main__":
     import argparse
+
+    # ログ設定を行う。デフォルトは INFO レベル
+    setup_logging()
 
     # コマンドライン引数を受け取る
     parser = argparse.ArgumentParser(description="スリザーリンク盤面を生成します")


### PR DESCRIPTION
## Summary
- remove global `logging.basicConfig` call from `generator.py`
- add `setup_logging` function so logging setup is explicit
- call `setup_logging` inside `if __name__ == '__main__'` blocks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b1b63a5c832ca91ed3962ba790ef