### PR TITLE
Use local RNG instead of global seed

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -8,7 +8,7 @@ import os
 import random
 import concurrent.futures
 import hashlib
-from typing import Any, Dict, List, Optional, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.solver import PuzzleSize, calculate_clues, count_solutions
@@ -36,7 +36,6 @@ from .validator import validate_puzzle, _has_zero_adjacent
 from .puzzle_builder import _build_puzzle_dict, _reduce_clues
 
 from .types import Puzzle
-
 
 
 logging.basicConfig(
@@ -110,8 +109,8 @@ def generate_puzzle(
     if difficulty not in ALLOWED_DIFFICULTIES:
         raise ValueError(f"difficulty は {ALLOWED_DIFFICULTIES} のいずれかで指定")
 
-    if seed is not None:
-        random.seed(seed)
+    # 乱数生成器を作成。シードを指定すると結果を再現できる
+    rng = random.Random(seed)
 
     generation_params = {
         "rows": rows,
@@ -135,7 +134,7 @@ def generate_puzzle(
         logger.info("空の盤面作成: %.3f 秒", time.perf_counter() - step_time)
 
         step_time = time.perf_counter()
-        _generate_random_loop(edges, size)
+        _generate_random_loop(edges, size, rng)
         if symmetry == "rotational":
             # 回転対称を希望する場合は生成したループを180度回転して重ねる
             _apply_rotational_symmetry(edges, size)
@@ -152,7 +151,7 @@ def generate_puzzle(
         logger.info("ヒント計算完了: %.3f 秒", time.perf_counter() - step_time)
 
         min_hint = max(1, int(rows * cols * MIN_HINT_RATIO.get(difficulty, 0.1)))
-        clues = _reduce_clues(clues_all, size, min_hint=min_hint)
+        clues = _reduce_clues(clues_all, size, rng, min_hint=min_hint)
 
         # 0 が縦横に並んでいないか確認
         if _has_zero_adjacent(

--- a/src/loop_builder.py
+++ b/src/loop_builder.py
@@ -15,8 +15,13 @@ def _create_empty_edges(size: PuzzleSize) -> Dict[str, List[List[bool]]]:
     return {"horizontal": horizontal, "vertical": vertical}
 
 
-def _generate_random_loop(edges: Dict[str, List[List[bool]]], size: PuzzleSize) -> None:
-    """バックトラックでランダムなループを生成する"""
+def _generate_random_loop(
+    edges: Dict[str, List[List[bool]]], size: PuzzleSize, rng: random.Random
+) -> None:
+    """バックトラックでランダムなループを生成する
+
+    :param rng: 乱数生成に利用する ``random.Random`` インスタンス
+    """
 
     degrees = [[0 for _ in range(size.cols + 1)] for _ in range(size.rows + 1)]
 
@@ -59,14 +64,14 @@ def _generate_random_loop(edges: Dict[str, List[List[bool]]], size: PuzzleSize) 
 
     min_len = max(2 * (size.rows + size.cols), 4)
 
-    start = (random.randint(0, size.rows), random.randint(0, size.cols))
+    start = (rng.randint(0, size.rows), rng.randint(0, size.cols))
     path: list[tuple[int, int]] = [start]
 
     def dfs(current: tuple[int, int]) -> bool:
         if len(path) >= min_len and current == start and len(path) > 1:
             return True
         directions = [(0, 1), (1, 0), (0, -1), (-1, 0)]
-        random.shuffle(directions)
+        rng.shuffle(directions)
         for dr, dc in directions:
             nr, nc = current[0] + dr, current[1] + dc
             if not (0 <= nr <= size.rows and 0 <= nc <= size.cols):

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -33,14 +33,18 @@ def _evaluate_difficulty(steps: int, depth: int) -> str:
 def _reduce_clues(
     clues: List[List[int]],
     size: PuzzleSize,
+    rng: random.Random,
     *,
     min_hint: int,
 ) -> List[List[int | None]]:
-    """ヒントをランダムに削減して一意性を保つ"""
+    """ヒントをランダムに削減して一意性を保つ
+
+    :param rng: 乱数生成に利用する ``random.Random`` インスタンス
+    """
 
     result: List[List[int | None]] = [[v for v in row] for row in clues]
     cells = [(r, c) for r in range(size.rows) for c in range(size.cols)]
-    random.shuffle(cells)
+    rng.shuffle(cells)
 
     for r, c in cells:
         if result[r][c] is None:


### PR DESCRIPTION
## Summary
- use `random.Random` for deterministic generation
- thread RNG through `_generate_random_loop` and `_reduce_clues`
- update docs and typing

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b1b83dac832cab8bd5138a7f8ef8