### PR TITLE
Always validate puzzles

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -204,8 +204,13 @@ def generate_puzzle(
         )
 
         # 生成した結果が仕様を満たすか簡易チェック
-        if symmetry != "rotational":
+        try:
             validate_puzzle(puzzle)
+        except ValueError as exc:
+            # 検証に失敗した場合は再試行
+            logger.warning("検証失敗: %s", exc)
+            last_edges = edges
+            continue
 
         stats = {
             "loop_length": loop_length,
@@ -248,8 +253,8 @@ def generate_puzzle(
             generation_params=generation_params,
             seed_hash=seed_hash,
         )
-        if symmetry != "rotational":
-            validate_puzzle(puzzle)
+        # フォールバック結果でも必ず検証を行う
+        validate_puzzle(puzzle)
         stats = {
             "loop_length": _count_edges(last_edges),
             "hint_count": sum(1 for row in clues_all for v in row if v is not None),

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -132,6 +132,8 @@ def test_generate_puzzle_symmetry() -> None:
         Dict[str, Any], generator.generate_puzzle(4, 4, symmetry="rotational", seed=7)
     )
     assert puzzle["symmetry"] == "rotational"
+    # 回転対称パズルも検証を行う
+    validator.validate_puzzle(puzzle)
 
 
 @pytest.mark.slow
@@ -139,6 +141,8 @@ def test_solution_edges_rotational() -> None:
     puzzle = cast(
         Dict[str, Any], generator.generate_puzzle(4, 4, symmetry="rotational", seed=42)
     )
+    # 生成された回転対称パズルを検証
+    validator.validate_puzzle(puzzle)
     edges = puzzle["solutionEdges"]
     size = solver.PuzzleSize(4, 4)
     horizontal = edges["horizontal"]


### PR DESCRIPTION
## Summary
- validate all generated puzzles regardless of symmetry
- retry when validation fails in generate_puzzle
- validate rotational puzzles in tests

## Testing
- `pytest -m "not slow" -q`

------
https://chatgpt.com/codex/tasks/task_e_6864b1bc3648832ca5c5ce8e28473dd3