### PR TITLE
docs: document generationParams and seedHash

### DIFF
--- a/MakeGridTraceSPECnew.md
+++ b/MakeGridTraceSPECnew.md
@@ -102,10 +102,10 @@ def generate_puzzle(
 | `createdBy`      | string  | 例: `"auto-gen-v1"`                           |
 | `createdAt`      | string  | ISO-8601 日付文字列                            |
 | `symmetry`       | string? | 対称性オプション                               |
-| `generationParams` | object | 呼び出しパラメータのエコーバック (未実装)      |
-| `seedHash`       | string  | シード値のハッシュ (未実装)                   |
+| `generationParams` | object | 呼び出しパラメータのエコーバック               |
+| `seedHash`       | string  | シード値のハッシュ                             |
 
-現状のコードでは `qualityScore`, `generationParams`, `seedHash`, `theme` などはまだ付与されません。今後の開発項目として残っています。
+現状のコードでは `qualityScore` と `theme` はまだ付与されません。今後の開発項目として残っています。
 
 ---
 
@@ -165,7 +165,7 @@ flowchart TD
 - Python 3.12 対応、pytest によるテストスイートあり
 - `generate_puzzle` 関数は v2 仕様の一部 (`schemaVersion`, `loopStats`, `symmetry`) を実装済み
 - ハード制約 H-1〜H-9 を `validate_puzzle` で検証済み
-- テーマ指定、Quality Score、seedHash などは未実装
+- テーマ指定と Quality Score は未実装
 - CLI スクリプト `python src/generator.py` および `python -m src.bulk_generator` で生成可能
 
 ---

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ python -m src.bulk_generator 4 4 2
 - `cluesFull` : すべてのセルに数値が入った解答用ヒント
 - `solutionEdges` : 正解ループの情報。水平線と垂直線の配列をまとめたもの
 - `difficulty` : 難易度ラベル
+- `generationParams` : 生成に使った引数を記録したオブジェクト
+- `seedHash` : シード値をハッシュ化した文字列
 
 より詳しく知りたい場合は `slitherlink_map_spec_v1.md` を参照してください。
 

--- a/src/generator.py
+++ b/src/generator.py
@@ -8,7 +8,7 @@ import os
 import random
 import concurrent.futures
 import hashlib
-from typing import Any, Dict, List, Optional, cast, TYPE_CHECKING
+from typing import Dict, List, Optional, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from src.solver import PuzzleSize, calculate_clues, count_solutions
@@ -36,7 +36,6 @@ from .validator import validate_puzzle, _has_zero_adjacent
 from .puzzle_builder import _build_puzzle_dict, _reduce_clues
 
 from .types import Puzzle
-
 
 
 logging.basicConfig(


### PR DESCRIPTION
## Summary
- remove unused typing import
- state that `generationParams` と `seedHash` が実装済みであることを仕様書に明記
- README に `generationParams` と `seedHash` を追記

## Testing
- `black .`
- `flake8`
- `mypy src`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864b1bd308c832caec83f3a5c5b327a