### PR TITLE
fix: add missing setup_logging

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -39,12 +39,18 @@ from .constants import MAX_SOLVER_STEPS
 from .types import Puzzle
 
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-)
-
 logger = logging.getLogger(__name__)
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """ログ出力の設定を行う関数"""
+
+    # logging.basicConfig でフォーマットやレベルを一括設定する
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
 
 # JSON スキーマのバージョン
 SCHEMA_VERSION = "2.0"


### PR DESCRIPTION
## Summary
- implement `setup_logging` in `generator.py`
- adjust top-level logging configuration

## Testing
- `black src tests`
- `flake8`
- `pytest -q` *(90s)*

------
https://chatgpt.com/codex/tasks/task_e_6864b6f2bd70832c8c0c5ccd68eb4bdd