### PR TITLE
Add quality score to puzzles

### DIFF
--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import math
 import random
 from typing import Any, Dict, List, Optional
 
@@ -15,6 +16,26 @@ Puzzle = Dict[str, Any]
 SCHEMA_VERSION = "2.0"
 
 # MAX_SOLVER_STEPS と _evaluate_difficulty は constants モジュールに移動
+
+
+def _calculate_quality_score(
+    clues: List[List[int | None]], curve_ratio: float, solver_steps: int
+) -> float:
+    """曲率比率とヒント密度から簡易的な品質スコアを計算する"""
+
+    cells = len(clues) * len(clues[0]) if clues else 0
+    if cells == 0:
+        return 0.0
+    hint_count = sum(1 for row in clues for v in row if v is not None)
+    p = hint_count / cells
+    if p in (0.0, 1.0):
+        entropy = 0.0
+    else:
+        entropy = -(p * math.log2(p) + (1 - p) * math.log2(1 - p))
+
+    score = 20 * math.log10(max(curve_ratio * 100, 0.01)) + 25 * entropy
+    score += min(20.0, 10000.0 / (solver_steps + 1))
+    return round(max(0.0, min(100.0, score)), 2)
 
 
 def _reduce_clues(
@@ -65,6 +86,7 @@ def _build_puzzle_dict(
     """パズル用の辞書オブジェクトを構築するヘルパー関数"""
 
     timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    qs = _calculate_quality_score(clues, curve_ratio, solver_stats["steps"])
     puzzle: Puzzle = {
         "schemaVersion": SCHEMA_VERSION,
         "id": f"sl_{size.rows}x{size.cols}_{difficulty}_{timestamp}",
@@ -84,10 +106,11 @@ def _build_puzzle_dict(
         "symmetry": symmetry,
         "generationParams": generation_params,
         "seedHash": seed_hash,
+        "qualityScore": qs,
         "createdBy": "auto-gen-v1",
         "createdAt": datetime.utcnow().date().isoformat(),
     }
     return puzzle
 
 
-__all__ = ["_build_puzzle_dict", "_reduce_clues"]
+__all__ = ["_build_puzzle_dict", "_reduce_clues", "_calculate_quality_score"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -26,6 +26,8 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
     assert "solverStats" in puzzle
     assert puzzle["solverStats"]["steps"] >= 0
     assert puzzle["solverStats"]["maxDepth"] >= 0
+    assert "qualityScore" in puzzle
+    assert 0 <= puzzle["qualityScore"] <= 100
     assert puzzle["generationParams"] == {
         "rows": 4,
         "cols": 4,


### PR DESCRIPTION
## Summary
- compute simple Quality Score using curve ratio, hint entropy and solver steps
- embed qualityScore in puzzle data
- test that qualityScore is within 0-100

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864ecc28000832c8f42f01b0dde0193