### PR TITLE
Add theme CLI option and fix UTC usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ python src/generator.py 4 4 --difficulty normal
 - `cols` : 盤面の列数。必須の数値です。
 - `--difficulty` : 難易度ラベル。`easy` / `normal` / `hard` / `expert` から選択。省略すると `easy`。
 - `--symmetry` : `rotational` を指定すると盤面を 180 度回転対称にします。
+- `--theme` : 現状は `border` を指定できます。盤面の外周だけを使ったテーマです。
 - `--seed` : 乱数シード。再現したいときに数値を指定します。
 - `--timeout` : 生成処理のタイムアウト秒数。指定しない場合は無制限。
 - `--parallel` : 並列生成プロセス数。複数指定すると生成を複数プロセスで試行します。

--- a/src/generator.py
+++ b/src/generator.py
@@ -332,10 +332,14 @@ def generate_puzzle_parallel(
     difficulty: str = "normal",
     seed: int | None = None,
     symmetry: Optional[str] = None,
+    theme: Optional[str] = None,
     return_stats: bool = False,
     jobs: int | None = None,
 ) -> Puzzle | tuple[Puzzle, Dict[str, int]]:
-    """複数プロセスで generate_puzzle を試行して最初の結果を返す"""
+    """複数プロセスで ``generate_puzzle`` を試行して最初の結果を返す
+
+    :param theme: 盤面のテーマを指定する文字列
+    """
 
     # 初期シードに ``seed`` を使い、プロセス番号でシードをずらして実行する
     # ``jobs`` が ``None`` の場合は CPU コア数を利用する
@@ -354,6 +358,7 @@ def generate_puzzle_parallel(
                 difficulty=difficulty,
                 seed=base_seed + i,
                 symmetry=symmetry,
+                theme=theme,
                 return_stats=return_stats,
             )
             for i in range(jobs)
@@ -467,6 +472,11 @@ if __name__ == "__main__":
         choices=["rotational"],
         help="回転対称にしたい場合に指定",
     )
+    parser.add_argument(
+        "--theme",
+        choices=["border"],
+        help="盤面のテーマを指定",
+    )
     parser.add_argument("--seed", type=int, default=None, help="乱数シード")
     parser.add_argument(
         "--timeout",
@@ -489,6 +499,7 @@ if __name__ == "__main__":
             difficulty=args.difficulty,
             seed=args.seed,
             symmetry=args.symmetry,
+            theme=args.theme,
             timeout_s=args.timeout,
             jobs=args.parallel,
         )
@@ -499,6 +510,7 @@ if __name__ == "__main__":
             difficulty=args.difficulty,
             seed=args.seed,
             symmetry=args.symmetry,
+            theme=args.theme,
             timeout_s=args.timeout,
         )
     pzl = cast(Puzzle, pzl_obj)

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+# datetime モジュールから UTC 定数も合わせてインポート
+from datetime import datetime, UTC
 import math
 import random
 from typing import Any, Dict, List, Optional
@@ -87,7 +88,8 @@ def _build_puzzle_dict(
 ) -> Puzzle:
     """パズル用の辞書オブジェクトを構築するヘルパー関数"""
 
-    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    # timezone-aware な UTC 時刻を取得する
+    timestamp = datetime.now(UTC).strftime("%Y%m%d%H%M%S")
     qs = _calculate_quality_score(clues, curve_ratio, solver_stats["steps"])
     puzzle: Puzzle = {
         "schemaVersion": SCHEMA_VERSION,
@@ -111,7 +113,8 @@ def _build_puzzle_dict(
         "seedHash": seed_hash,
         "qualityScore": qs,
         "createdBy": "auto-gen-v1",
-        "createdAt": datetime.utcnow().date().isoformat(),
+        # ISO8601 形式の UTC 日付文字列を保存
+        "createdAt": datetime.now(UTC).date().isoformat(),
         "partial": partial,
     }
     return puzzle


### PR DESCRIPTION
## Summary
- fix deprecated `datetime.utcnow()` usage by switching to timezone-aware `datetime.now(UTC)`
- add optional `--theme` argument for command line interface
- wire the theme parameter through `generate_puzzle_parallel`
- document the new option in README

## Testing
- `black -q src tests`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68650695a68c832cafb7e7d8c80ec573