### PR TITLE
Improve clue reduction with zero check

### DIFF
--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from .solver import PuzzleSize, count_solutions
 from .constants import MAX_SOLVER_STEPS, _evaluate_difficulty
+from . import validator
 
 Puzzle = Dict[str, Any]
 
@@ -95,6 +96,9 @@ def _reduce_clues(
 ) -> List[List[int | None]]:
     """ヒントをランダムに削減して一意性を保つ
 
+    生成途中で ``0`` が縦横に隣接してしまうとハード制約 H-8 を満たさなくなる。
+    そのため削除後に ``_has_zero_adjacent`` を確認し、違反する場合は削除を戻す。
+
     :param rng: 乱数生成に利用する ``random.Random`` インスタンス
     """
 
@@ -111,6 +115,9 @@ def _reduce_clues(
         if (
             hint_count < min_hint
             or count_solutions(result, size, limit=2, step_limit=MAX_SOLVER_STEPS) != 1
+            or validator._has_zero_adjacent(
+                [[v if v is not None else -1 for v in row] for row in result]
+            )
         ):
             result[r][c] = original
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -3,6 +3,7 @@ import hashlib
 from pathlib import Path
 import sys
 from typing import Any, Dict, cast
+import random
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,6 +13,7 @@ from src import puzzle_io  # noqa: E402
 from src import validator  # noqa: E402
 from src import solver  # noqa: E402
 from src import puzzle_builder  # noqa: E402
+from src import loop_builder  # noqa: E402
 
 
 def test_generate_puzzle_structure(tmp_path: Path) -> None:
@@ -256,3 +258,16 @@ def test_count_solutions_unique() -> None:
     size = solver.PuzzleSize(3, 3)
     count = solver.count_solutions(puzzle["clues"], size, limit=2, step_limit=500000)
     assert count == 1
+
+
+def test_reduce_clues_zero_adjacent() -> None:
+    size = solver.PuzzleSize(3, 3)
+    rng_loop = random.Random(0)
+    edges = loop_builder._create_empty_edges(size)
+    loop_builder._generate_random_loop(edges, size, rng_loop)
+    clues = solver.calculate_clues(edges, size)
+    assert any(0 in row for row in clues)
+    reduced = puzzle_builder._reduce_clues(clues, size, random.Random(1), min_hint=1)
+    assert not validator._has_zero_adjacent(
+        [[v if v is not None else -1 for v in row] for row in reduced]
+    )


### PR DESCRIPTION
## Summary
- check zero adjacency while removing clues
- test helper ensures clue reduction keeps zeros separate

## Testing
- `black -q .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651787e164832c843e097cbb26536d