### PR TITLE
Add solver step limit option

### DIFF
--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -93,6 +93,7 @@ def _reduce_clues(
     rng: random.Random,
     *,
     min_hint: int,
+    step_limit: int = MAX_SOLVER_STEPS,
 ) -> List[List[int | None]]:
     """ヒントをランダムに削減して一意性を保つ
 
@@ -100,6 +101,7 @@ def _reduce_clues(
     そのため削除後に ``_has_zero_adjacent`` を確認し、違反する場合は削除を戻す。
 
     :param rng: 乱数生成に利用する ``random.Random`` インスタンス
+    :param step_limit: ソルバーに渡すステップ上限
     """
 
     result: List[List[int | None]] = [[v for v in row] for row in clues]
@@ -114,7 +116,7 @@ def _reduce_clues(
         hint_count = sum(1 for row in result for v in row if v is not None)
         if (
             hint_count < min_hint
-            or count_solutions(result, size, limit=2, step_limit=MAX_SOLVER_STEPS) != 1
+            or count_solutions(result, size, limit=2, step_limit=step_limit) != 1
             or validator._has_zero_adjacent(
                 [[v if v is not None else -1 for v in row] for row in result]
             )

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -38,6 +38,7 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
         "seed": 0,
         "symmetry": None,
         "theme": None,
+        "solverStepLimit": generator.MAX_SOLVER_STEPS,
     }
     assert puzzle["seedHash"] == hashlib.sha256(b"0").hexdigest()
     calc = solver.calculate_clues(puzzle["solutionEdges"], solver.PuzzleSize(4, 4))
@@ -247,6 +248,7 @@ def test_generation_params_and_seedhash() -> None:
         "seed": 42,
         "symmetry": "rotational",
         "theme": None,
+        "solverStepLimit": generator.MAX_SOLVER_STEPS,
     }
     assert puzzle["generationParams"] == expected
     assert puzzle["seedHash"] == hashlib.sha256(b"42").hexdigest()
@@ -271,3 +273,11 @@ def test_reduce_clues_zero_adjacent() -> None:
     assert not validator._has_zero_adjacent(
         [[v if v is not None else -1 for v in row] for row in reduced]
     )
+
+
+def test_generate_puzzle_step_limit() -> None:
+    puzzle = cast(
+        Dict[str, Any],
+        generator.generate_puzzle(3, 3, seed=5, solver_step_limit=1000),
+    )
+    assert puzzle["generationParams"]["solverStepLimit"] == 1000


### PR DESCRIPTION
## Summary
- allow generator to set solver step limit
- propagate step limit through puzzle generation and metadata
- update tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651b3c4a2c832c9a0f0776bad190d0