### PR TITLE
Fix module name conflict

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -38,7 +38,8 @@ from .validator import validate_puzzle, _has_zero_adjacent
 from .constants import MAX_SOLVER_STEPS
 from .puzzle_builder import _reduce_clues, _build_puzzle_dict
 
-from .types import Puzzle
+# 標準ライブラリの ``types`` と名前が衝突しないよう ``puzzle_types`` に変更
+from .puzzle_types import Puzzle
 
 
 logger = logging.getLogger(__name__)

--- a/src/puzzle_io.py
+++ b/src/puzzle_io.py
@@ -6,7 +6,8 @@ import json
 from pathlib import Path
 from typing import List
 
-from .types import Puzzle
+# ``types`` モジュールとの衝突を避けるため ``puzzle_types`` を使用
+from .puzzle_types import Puzzle
 
 
 def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:

--- a/src/puzzle_types.py
+++ b/src/puzzle_types.py
@@ -1,0 +1,12 @@
+"""共通で使う型エイリアスをまとめたモジュール
+
+Python 標準ライブラリの ``types`` モジュールと名前が衝突しないよう、
+このファイル名を ``puzzle_types`` としている。
+"""
+
+from typing import Any, Dict
+
+# Puzzle データを表す辞書型。キーは文字列で値は任意の型を許容
+Puzzle = Dict[str, Any]
+
+__all__ = ["Puzzle"]

--- a/src/types.py
+++ b/src/types.py
@@ -1,8 +1,0 @@
-"""共通で使う型エイリアスをまとめたモジュール"""
-
-from typing import Any, Dict
-
-# Puzzle データを表す辞書型。キーは文字列で値は任意の型を許容
-Puzzle = Dict[str, Any]
-
-__all__ = ["Puzzle"]

--- a/src/validator.py
+++ b/src/validator.py
@@ -7,7 +7,8 @@ from .solver import PuzzleSize, calculate_clues
 from .loop_builder import _calculate_curve_ratio
 from typing import List
 
-from .types import Puzzle
+# 標準 ``types`` と区別するため自作モジュール名を変更
+from .puzzle_types import Puzzle
 
 
 def _has_zero_adjacent(clues: List[List[int]]) -> bool:


### PR DESCRIPTION
## Summary
- rename local `types` module to avoid clashing with Python standard library
- update imports in generator, puzzle_io and validator

## Testing
- `black . --check`
- `flake8`
- `mypy src`
- `pytest -q -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_6865971ba2a8832c80142de2b0ad1ed5