### PR TITLE
Fix direct execution imports

### DIFF
--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -3,15 +3,20 @@
 from __future__ import annotations
 
 import argparse
+from typing import TYPE_CHECKING
 
-try:
-    # パッケージ実行時は相対インポート
-    from .generator import generate_multiple_puzzles, puzzle_to_ascii, setup_logging
-    from .puzzle_io import save_puzzles
-except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
-    # スクリプトとして直接実行されたときは同じディレクトリからインポートする
-    from generator import generate_multiple_puzzles, puzzle_to_ascii, setup_logging
-    from puzzle_io import save_puzzles
+if TYPE_CHECKING:
+    from src.generator import generate_multiple_puzzles, puzzle_to_ascii, setup_logging
+    from src.puzzle_io import save_puzzles
+else:
+    try:
+        # パッケージ実行時は相対インポート
+        from .generator import generate_multiple_puzzles, puzzle_to_ascii, setup_logging
+        from .puzzle_io import save_puzzles
+    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+        from generator import generate_multiple_puzzles, puzzle_to_ascii, setup_logging
+        from puzzle_io import save_puzzles
 
 
 # コマンドラインから実行される関数

--- a/src/generator.py
+++ b/src/generator.py
@@ -24,9 +24,8 @@ else:
             count_solutions,
         )
 
-try:
-    # パッケージとして実行された場合の相対インポート
-    from .loop_builder import (
+if TYPE_CHECKING:
+    from src.loop_builder import (
         _create_empty_edges,
         _generate_random_loop,
         _count_edges,
@@ -35,29 +34,46 @@ try:
         _apply_vertical_symmetry,
         _apply_horizontal_symmetry,
     )
-    from .puzzle_io import save_puzzle
-    from .validator import validate_puzzle, _has_zero_adjacent
-    from .constants import MAX_SOLVER_STEPS
-    from .puzzle_builder import _reduce_clues, _build_puzzle_dict
+    from src.puzzle_io import save_puzzle
+    from src.validator import validate_puzzle, _has_zero_adjacent
+    from src.constants import MAX_SOLVER_STEPS
+    from src.puzzle_builder import _reduce_clues, _build_puzzle_dict
+    from src.puzzle_types import Puzzle
+else:
+    try:
+        # パッケージとして実行された場合の相対インポート
+        from .loop_builder import (
+            _create_empty_edges,
+            _generate_random_loop,
+            _count_edges,
+            _calculate_curve_ratio,
+            _apply_rotational_symmetry,
+            _apply_vertical_symmetry,
+            _apply_horizontal_symmetry,
+        )
+        from .puzzle_io import save_puzzle
+        from .validator import validate_puzzle, _has_zero_adjacent
+        from .constants import MAX_SOLVER_STEPS
+        from .puzzle_builder import _reduce_clues, _build_puzzle_dict
 
-    # 標準ライブラリの ``types`` と名前が衝突しないよう ``puzzle_types`` に変更
-    from .puzzle_types import Puzzle
-except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
-    # スクリプトとして直接実行されたときは同じディレクトリからインポートする
-    from loop_builder import (
-        _create_empty_edges,
-        _generate_random_loop,
-        _count_edges,
-        _calculate_curve_ratio,
-        _apply_rotational_symmetry,
-        _apply_vertical_symmetry,
-        _apply_horizontal_symmetry,
-    )
-    from puzzle_io import save_puzzle
-    from validator import validate_puzzle, _has_zero_adjacent
-    from constants import MAX_SOLVER_STEPS
-    from puzzle_builder import _reduce_clues, _build_puzzle_dict
-    from puzzle_types import Puzzle
+        # 標準ライブラリの ``types`` と名前が衝突しないよう ``puzzle_types`` に変更
+        from .puzzle_types import Puzzle
+    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+        from loop_builder import (
+            _create_empty_edges,
+            _generate_random_loop,
+            _count_edges,
+            _calculate_curve_ratio,
+            _apply_rotational_symmetry,
+            _apply_vertical_symmetry,
+            _apply_horizontal_symmetry,
+        )
+        from puzzle_io import save_puzzle
+        from validator import validate_puzzle, _has_zero_adjacent
+        from constants import MAX_SOLVER_STEPS
+        from puzzle_builder import _reduce_clues, _build_puzzle_dict
+        from puzzle_types import Puzzle
 
 
 logger = logging.getLogger(__name__)

--- a/src/loop_builder.py
+++ b/src/loop_builder.py
@@ -2,10 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 import random
 
-from .solver import PuzzleSize
+if TYPE_CHECKING:
+    from src.solver import PuzzleSize
+else:
+    try:
+        # パッケージとして実行された場合の相対インポート
+        from .solver import PuzzleSize
+    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+        from solver import PuzzleSize
 
 
 def _create_empty_edges(size: PuzzleSize) -> Dict[str, List[List[bool]]]:

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -6,11 +6,23 @@ from __future__ import annotations
 from datetime import datetime, UTC
 import math
 import random
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from .solver import PuzzleSize, count_solutions
-from .constants import MAX_SOLVER_STEPS, _evaluate_difficulty
-from . import validator
+if TYPE_CHECKING:
+    from src.solver import PuzzleSize, count_solutions
+    from src.constants import MAX_SOLVER_STEPS, _evaluate_difficulty
+    from src import validator
+else:
+    try:
+        # パッケージとして実行された場合の相対インポート
+        from .solver import PuzzleSize, count_solutions
+        from .constants import MAX_SOLVER_STEPS, _evaluate_difficulty
+        from . import validator
+    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+        from solver import PuzzleSize, count_solutions
+        from constants import MAX_SOLVER_STEPS, _evaluate_difficulty
+        import validator
 
 Puzzle = Dict[str, Any]
 

--- a/src/puzzle_io.py
+++ b/src/puzzle_io.py
@@ -4,10 +4,18 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import List
+from typing import List, TYPE_CHECKING
 
 # ``types`` モジュールとの衝突を避けるため ``puzzle_types`` を使用
-from .puzzle_types import Puzzle
+if TYPE_CHECKING:
+    from src.puzzle_types import Puzzle
+else:
+    try:
+        # パッケージとして実行された場合の相対インポート
+        from .puzzle_types import Puzzle
+    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+        from puzzle_types import Puzzle
 
 
 def save_puzzle(puzzle: Puzzle, directory: str | Path = "data") -> Path:

--- a/src/validator.py
+++ b/src/validator.py
@@ -2,13 +2,25 @@
 
 from __future__ import annotations
 
+from typing import List, TYPE_CHECKING
 
-from .solver import PuzzleSize, calculate_clues
-from .loop_builder import _calculate_curve_ratio
-from typing import List
+if TYPE_CHECKING:
+    from src.solver import PuzzleSize, calculate_clues
+    from src.loop_builder import _calculate_curve_ratio
+    from src.puzzle_types import Puzzle
+else:
+    try:
+        # パッケージとして実行された場合の相対インポート
+        from .solver import PuzzleSize, calculate_clues
+        from .loop_builder import _calculate_curve_ratio
 
-# 標準 ``types`` と区別するため自作モジュール名を変更
-from .puzzle_types import Puzzle
+        # 標準 ``types`` と区別するため自作モジュール名を変更
+        from .puzzle_types import Puzzle
+    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
+        from solver import PuzzleSize, calculate_clues
+        from loop_builder import _calculate_curve_ratio
+        from puzzle_types import Puzzle
 
 
 def _has_zero_adjacent(clues: List[List[int]]) -> bool:


### PR DESCRIPTION
## Summary
- allow modules to fall back to local imports when executed as scripts
- update generator and helpers to use TYPE_CHECKING blocks for mypy

## Testing
- `flake8`
- `mypy src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68659bd0b2e4832c8f4eddc8b3c4302e