### PR TITLE
Fix runtime warning for module execution

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,12 +1,7 @@
-"""generator モジュールの公開関数をまとめる"""
+"""generator や入出力モジュールの関数を公開するパッケージ用モジュール"""
 
-from .generator import (
-    generate_puzzle,
-    generate_multiple_puzzles,
-    puzzle_to_ascii,
-)
-from .puzzle_io import save_puzzle, save_puzzles
-from .validator import validate_puzzle
+from importlib import import_module
+from typing import Any
 
 __all__ = [
     "generate_puzzle",
@@ -16,3 +11,21 @@ __all__ = [
     "save_puzzles",
     "puzzle_to_ascii",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """必要になったタイミングで対象モジュールを読み込む"""
+
+    if name in {"generate_puzzle", "generate_multiple_puzzles", "puzzle_to_ascii"}:
+        module = import_module(".generator", __name__)
+        return getattr(module, name)
+
+    if name in {"save_puzzle", "save_puzzles"}:
+        module = import_module(".puzzle_io", __name__)
+        return getattr(module, name)
+
+    if name == "validate_puzzle":
+        module = import_module(".validator", __name__)
+        return getattr(module, name)
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name}")


### PR DESCRIPTION
## Summary
- avoid eager import in `src.__init__` that triggered warnings when running with `-m`

## Testing
- `pytest -q`
- `python -m src.generator 2 2 --difficulty easy`

------
https://chatgpt.com/codex/tasks/task_e_6865a1160b68832c800f1451ee68ad13