### PR TITLE
Add maze theme loop generation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@
 
 - [x] **ヒント最適化(Simulated Annealing)**
   - 仕様書の生成パイプライン D で予定されている焼きなまし最適化を実装しました【F:MakeGridTraceSPECnew.md†L144-L160】。
-- [ ] **テーマ(`theme`)の拡充**
-  - 現在は `"border"` のみ対応。将来的に複数テーマを追加予定【F:MakeGridTraceSPECnew.md†L176-L177】。
+- [x] **テーマ(`theme`)の拡充**
+  - `"maze"` テーマを追加し、ランダム生成から曲がりの多いループを選択するロジックを実装しました【F:src/generator.py†L166-L191】。
 - [ ] **品質指標(Quality Score)の改良**
   - 曲率比率とヒント分散度以外の統計も用いて計算する計画【F:MakeGridTraceSPECnew.md†L177-L179】。
 - [ ] **solverStats の詳細化**

--- a/src/generator.py
+++ b/src/generator.py
@@ -45,7 +45,6 @@ try:
 except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
     # スクリプトとして直接実行されたときは同じディレクトリからインポートする
     from loop_builder import (
-
         _create_empty_edges,
         _generate_random_loop,
         _count_edges,
@@ -153,7 +152,12 @@ def _create_loop(
     symmetry: Optional[str],
     theme: Optional[str],
 ) -> tuple[Dict[str, List[List[bool]]], int, float]:
-    """ループを生成し長さと曲率を返す"""
+    """ループを生成し長さと曲率を返す
+
+    ``theme`` に ``"border"`` を指定すると外周のみ、
+    ``"maze"`` を指定すると曲がりの多いループを選ぶ。
+    それ以外はランダム生成となる。
+    """
 
     # 対称性のあるループは失敗しやすいため複数回試行する
     for _ in range(5):
@@ -165,6 +169,25 @@ def _create_loop(
             for r in range(size.rows):
                 edges["vertical"][r][0] = True
                 edges["vertical"][r][size.cols] = True
+        elif theme == "maze":
+            # ランダムループを複数回生成し、より長く曲がりの多いものを採用する
+            best_edges = None
+            best_score = -1.0
+            for _ in range(10):
+                cand = _create_empty_edges(size)
+                _generate_random_loop(cand, size, rng)
+                if not _validate_edges(cand, size):
+                    continue
+                length = _count_edges(cand)
+                curve = _calculate_curve_ratio(cand, size)
+                score = length + curve * 100.0
+                if score > best_score:
+                    best_edges = cand
+                    best_score = score
+            if best_edges is not None:
+                edges = best_edges
+            else:
+                _generate_random_loop(edges, size, rng)
         else:
             _generate_random_loop(edges, size, rng)
 
@@ -590,7 +613,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--theme",
-        choices=["border"],
+        choices=["border", "maze"],
         help="盤面のテーマを指定",
     )
     parser.add_argument("--seed", type=int, default=None, help="乱数シード")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -78,6 +78,16 @@ def test_generate_puzzle_theme_border() -> None:
     assert length == 2 * (size.rows + size.cols)
 
 
+def test_generate_puzzle_theme_maze() -> None:
+    puzzle = cast(
+        Dict[str, Any],
+        generator.generate_puzzle(3, 3, difficulty="easy", theme="maze", seed=11),
+    )
+    validator.validate_puzzle(puzzle)
+    assert puzzle["theme"] == "maze"
+    assert puzzle["generationParams"]["theme"] == "maze"
+
+
 def test_validate_puzzle() -> None:
     puzzle = cast(Dict[str, Any], generator.generate_puzzle(4, 4, seed=0))
     # エラーが出ないことを確認


### PR DESCRIPTION
## Summary
- support maze theme loops in generator
- expose new theme choice on CLI
- document progress in ROADMAP
- test maze themed puzzle generation

## Testing
- `black -q .`
- `flake8`
- `mypy src tests` *(fails: module import errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a3070aa4832ca53020e0a8c0f00a