### PR TITLE
Implement solverStats rule counts

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,8 @@
   - `"maze"` テーマを追加し、ランダム生成から曲がりの多いループを選択するロジックを実装しました【F:src/generator.py†L166-L191】。
 - [x] **品質指標(Quality Score)の改良**
   - ヒント密度や行列バランスを評価に加え、より細かな指標で算出するよう更新しました【F:src/puzzle_builder.py†L88-L116】。
-- [ ] **solverStats の詳細化**
-  - ソルバーが使った手筋(解き方)の種類や回数を記録する機能は未実装【F:MakeGridTraceSPECnew.md†L179-L180】。
+- [x] **solverStats の詳細化**
+  - 手筋別の枝刈り回数 (``ruleVertex`` / ``ruleClue``) を ``solverStats`` に追加しました【F:src/solver.py†L142-L158】【F:src/puzzle_builder.py†L255-L259】。
 - [ ] **CI 強化(品質ヒストグラム)**
   - Quality Score の分布を解析し P95≥70 を目標とする仕組みは未導入【F:MakeGridTraceSPECnew.md†L181-L182】。
 - [ ] **ドキュメント整備**

--- a/src/generator.py
+++ b/src/generator.py
@@ -244,8 +244,10 @@ def generate_puzzle(
         ``(Puzzle, dict)`` のタプルを返す
 
     生成結果の ``solverStats`` フィールドには、
-    ソルバーが使った探索ステップ数 (``steps``) と
-    最大探索深さ (``maxDepth``) を記録します。
+    ソルバーが使った探索ステップ数 (``steps``)、
+    最大探索深さ (``maxDepth``)、
+    頂点次数ルールで枝刈りした回数 (``ruleVertex``)、
+    ヒント矛盾で枝刈りした回数 (``ruleClue``) を記録します。
     """
 
     if difficulty not in ALLOWED_DIFFICULTIES:

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 # datetime モジュールから UTC 定数も合わせてインポート
 from datetime import datetime, UTC
 import math
-import statistics
 import random
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
@@ -96,7 +95,9 @@ def _calculate_quality_score(
 
     # 行・列ごとのヒント数のばらつきを評価 (均一なら 1.0)
     row_counts = [sum(1 for v in row if v is not None) for row in clues]
-    col_counts = [sum(1 for row in clues if row[c] is not None) for c in range(len(clues[0]))]
+    col_counts = [
+        sum(1 for row in clues if row[c] is not None) for c in range(len(clues[0]))
+    ]
     if hint_count > 0:
         row_balance = 1.0 - (max(row_counts) - min(row_counts)) / hint_count
         col_balance = 1.0 - (max(col_counts) - min(col_counts)) / hint_count
@@ -256,6 +257,8 @@ def _build_puzzle_dict(
         "solverStats": {
             "steps": solver_stats["steps"],
             "maxDepth": solver_stats["max_depth"],
+            "ruleVertex": solver_stats.get("rule_vertex", 0),
+            "ruleClue": solver_stats.get("rule_clue", 0),
         },
         "difficulty": difficulty,
         "difficultyEval": _evaluate_difficulty(

--- a/src/solver.py
+++ b/src/solver.py
@@ -131,7 +131,16 @@ def count_solutions(
     return_stats: bool = False,
     step_limit: int | None = None,
 ) -> int | tuple[int, Dict[str, int]]:
-    """バックトラックで解の個数を数える簡易ソルバー"""
+    """バックトラックで解の個数を数える簡易ソルバー
+
+    ``return_stats`` が ``True`` の場合は探索統計を返す。
+    統計には以下の項目が含まれる。
+
+    - ``steps``: 再帰呼び出し回数
+    - ``max_depth``: 最大再帰深さ
+    - ``rule_vertex``: 頂点次数が 2 を超えて枝刈りした回数
+    - ``rule_clue``: ヒント矛盾で枝刈りした回数
+    """
 
     if step_limit is None and return_stats:
         step_limit = 500000  # 解析ステップ数の上限
@@ -141,9 +150,11 @@ def count_solutions(
     solutions = 0
     steps = 0
     max_depth = 0
+    rule_vertex = 0
+    rule_clue = 0
 
     def dfs(idx: int, depth: int) -> None:
-        nonlocal solutions, steps, max_depth
+        nonlocal solutions, steps, max_depth, rule_vertex, rule_clue
         steps += 1
         if depth > max_depth:
             max_depth = depth
@@ -205,6 +216,7 @@ def count_solutions(
             ok = True
             for vr, vc in edge.vertices:
                 if board.vertex_degree[vr][vc] > 2:
+                    rule_vertex += 1
                     ok = False
                     break
             if ok:
@@ -215,6 +227,7 @@ def count_solutions(
                     used = board.cell_count[cr][cc]
                     unknown = board.cell_unknown[cr][cc]
                     if used > clue or used + unknown < clue:
+                        rule_clue += 1
                         ok = False
                         break
             if ok:
@@ -229,7 +242,12 @@ def count_solutions(
 
     dfs(0, 0)
     if return_stats:
-        return solutions, {"steps": steps, "max_depth": max_depth}
+        return solutions, {
+            "steps": steps,
+            "max_depth": max_depth,
+            "rule_vertex": rule_vertex,
+            "rule_clue": rule_clue,
+        }
     return solutions
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -29,6 +29,8 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
     assert "solverStats" in puzzle
     assert puzzle["solverStats"]["steps"] >= 0
     assert puzzle["solverStats"]["maxDepth"] >= 0
+    assert puzzle["solverStats"]["ruleVertex"] >= 0
+    assert puzzle["solverStats"]["ruleClue"] >= 0
     assert "qualityScore" in puzzle
     assert 0 <= puzzle["qualityScore"] <= 100
     assert puzzle["generationParams"] == {
@@ -61,6 +63,12 @@ def test_save_puzzle(tmp_path: Path) -> None:
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["id"].startswith("sl_4x4_easy_")
     assert "solverStats" in data
+    assert set(data["solverStats"].keys()) >= {
+        "steps",
+        "maxDepth",
+        "ruleVertex",
+        "ruleClue",
+    }
 
 
 def test_generate_puzzle_theme_border() -> None:


### PR DESCRIPTION
## Summary
- record `rule_vertex` and `rule_clue` counts in solver
- expose new stats in puzzle builder
- document solverStats fields in generator docstring
- update tests for new fields
- check off solverStats item in ROADMAP

## Testing
- `flake8`
- `mypy --ignore-missing-imports --allow-redefinition src/solver.py src/puzzle_builder.py src/generator.py tests/test_generator.py` *(fails: "Name \"_create_empty_edges\" already defined" etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865ad32bc38832cbaa7c4cb4eb4e732