### PR TITLE
Add spiral theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ python -m src.generator 4 4 --difficulty normal
 - `--difficulty` : 難易度ラベル。`easy` / `normal` / `hard` / `expert` から選択。省略すると `easy`。
 - `--symmetry` : `rotational`, `vertical`, `horizontal` のいずれかを指定すると
   回転対称・上下対称・左右対称の盤面を生成します。
-- `--theme` : `border` を指定すると外周のみを使った盤面を生成します。
+- `--theme` : `border` のほか `maze`, `spiral` を指定できます。テーマごとに
+  ループ形状が変わります。
 - `--seed` : 乱数シード。再現したいときに数値を指定します。
 - `--timeout` : 生成処理のタイムアウト秒数。指定しない場合は無制限。
 - `--parallel` : 並列生成プロセス数。複数指定すると生成を複数プロセスで試行します。

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@
 - [x] **ヒント最適化(Simulated Annealing)**
   - 仕様書の生成パイプライン D で予定されている焼きなまし最適化を実装しました【F:MakeGridTraceSPECnew.md†L144-L160】。
 - [x] **テーマ(`theme`)の拡充**
-  - `"maze"` テーマを追加し、ランダム生成から曲がりの多いループを選択するロジックを実装しました【F:src/generator.py†L166-L191】。
+  - `"maze"` と `"spiral"` テーマを追加し、ランダム生成から曲がりの多いループを選択するロジックを実装しました【F:src/generator.py†L174-L214】。
 - [x] **品質指標(Quality Score)の改良**
   - ヒント密度や行列バランスを評価に加え、より細かな指標で算出するよう更新しました【F:src/puzzle_builder.py†L88-L116】。
 - [x] **solverStats の詳細化**

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -96,6 +96,16 @@ def test_generate_puzzle_theme_maze() -> None:
     assert puzzle["generationParams"]["theme"] == "maze"
 
 
+def test_generate_puzzle_theme_spiral() -> None:
+    puzzle = cast(
+        Dict[str, Any],
+        generator.generate_puzzle(3, 3, difficulty="easy", theme="spiral", seed=12),
+    )
+    validator.validate_puzzle(puzzle)
+    assert puzzle["theme"] == "spiral"
+    assert puzzle["generationParams"]["theme"] == "spiral"
+
+
 def test_validate_puzzle() -> None:
     puzzle = cast(Dict[str, Any], generator.generate_puzzle(4, 4, seed=0))
     # エラーが出ないことを確認


### PR DESCRIPTION
## Summary
- support spiral puzzle theme
- expose new theme via CLI and docs
- document feature in roadmap
- test spiral theme generation

## Testing
- `black -q .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865b5dcacc4832c97582ee99038e724