### PR TITLE
Add parallel map generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,17 +70,19 @@ python -m src.generator 4 4 --difficulty normal
 - `--seed` : 乱数シード。再現したいときに数値を指定します。
 - `--timeout` : 生成処理のタイムアウト秒数。指定しない場合は無制限。
 - `--parallel` : 並列生成プロセス数。複数指定すると生成を複数プロセスで試行します。
+- `--jobs` : `bulk_generator.py` 用の並列生成プロセス数。値を増やすと早く生成できます。
 
 ### 複数の難易度をまとめて生成する
 
 `bulk_generator.py` を使うと、4 種類の難易度を同数生成して一つの JSON ファイルに保存できます。
 
+
 ```bash
 # 相対インポートを使っているため `-m` オプションでモジュールとして実行する
-python -m src.bulk_generator 4 4 2
+python -m src.bulk_generator 4 4 2 --jobs 4
 ```
 
-1 番目と 2 番目の引数は盤面の行数と列数、3 番目の引数は各難易度で何問生成するかを指定します。出力は `data/map_gridtrace.json` に保存されます。
+1 番目と 2 番目の引数は盤面の行数と列数、3 番目の引数は各難易度で何問生成するかを指定します。`--jobs` を増やすと複数プロセスで並列に生成できます。出力は `data/map_gridtrace.json` に保存されます。
 
 ## 3. マップを保存する
 

--- a/src/bulk_generator.py
+++ b/src/bulk_generator.py
@@ -31,9 +31,17 @@ def main() -> None:
     parser.add_argument(
         "count_each", type=int, default=1, help="各難易度の生成数 (デフォルト:1)"
     )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=1,
+        help="並列生成プロセス数",
+    )
     args = parser.parse_args()
 
-    puzzles = generate_multiple_puzzles(args.rows, args.cols, args.count_each)
+    puzzles = generate_multiple_puzzles(
+        args.rows, args.cols, args.count_each, jobs=args.jobs
+    )
     path = save_puzzles(puzzles)
     print(f"{path} を作成しました")
     # 生成した各パズルを ASCII で表示

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -248,6 +248,12 @@ def test_generate_puzzle_parallel() -> None:
     validator.validate_puzzle(puzzle)
 
 
+@pytest.mark.slow
+def test_generate_multiple_parallel() -> None:
+    puzzles = generator.generate_multiple_puzzles(3, 3, count_each=1, seed=8, jobs=2)
+    assert len(puzzles) == 4
+
+
 def test_hint_dispersion_helper() -> None:
     clues = [
         [0, None, 2, None],


### PR DESCRIPTION
## Summary
- add optional `jobs` parameter to generate_multiple_puzzles and implement multiprocessing
- allow bulk_generator to specify `--jobs`
- document new option in README
- test parallel generation for multiple puzzles

## Testing
- `flake8`
- `black --check .`
- `mypy src tests` *(fails: several missing stubs and typing errors)*
- `pytest -m "not slow" -q` *(partial run, 4 passed, 8 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_6865b906def8832c8c9cd537b2feaf9c