### PR TITLE
整理済み import

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -11,21 +11,18 @@ import hashlib
 from typing import Dict, List, Optional, cast, TYPE_CHECKING
 
 if TYPE_CHECKING:
+    # 型チェック時は絶対インポートを使用する
     from src.solver import PuzzleSize, calculate_clues, count_solutions
 else:
     try:
-        # パッケージとして実行された場合の相対インポート
+        # パッケージ実行時は相対インポート
         from .solver import PuzzleSize, calculate_clues, count_solutions
     except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
         # スクリプトとして直接実行されたときは同じディレクトリからインポートする
-        from solver import (
-            PuzzleSize,
-            calculate_clues,
-            count_solutions,
-        )
+        from solver import PuzzleSize, calculate_clues, count_solutions
 
 try:
-    # パッケージとして実行された場合の相対インポート
+    # loop_builder モジュールから各種関数を読み込む
     from .loop_builder import (
         _create_empty_edges,
         _generate_random_loop,
@@ -35,15 +32,7 @@ try:
         _apply_vertical_symmetry,
         _apply_horizontal_symmetry,
     )
-    from .puzzle_io import save_puzzle
-    from .validator import validate_puzzle, _has_zero_adjacent
-    from .constants import MAX_SOLVER_STEPS
-    from .puzzle_builder import _reduce_clues, _build_puzzle_dict, _optimize_clues
-
-    # 標準ライブラリの ``types`` と名前が衝突しないよう ``puzzle_types`` に変更
-    from .puzzle_types import Puzzle
 except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
-    # スクリプトとして直接実行されたときは同じディレクトリからインポートする
     from loop_builder import (
         _create_empty_edges,
         _generate_random_loop,
@@ -54,46 +43,31 @@ except ImportError:  # pragma: no cover - スクリプト実行時のフォー�
         _apply_horizontal_symmetry,
     )
 
-    from src.puzzle_io import save_puzzle
-    from src.validator import validate_puzzle, _has_zero_adjacent
-    from src.constants import MAX_SOLVER_STEPS
-    from src.puzzle_builder import _reduce_clues, _build_puzzle_dict
-    from src.puzzle_types import Puzzle
-else:
-    try:
-        # パッケージとして実行された場合の相対インポート
-        from .loop_builder import (
-            _create_empty_edges,
-            _generate_random_loop,
-            _count_edges,
-            _calculate_curve_ratio,
-            _apply_rotational_symmetry,
-            _apply_vertical_symmetry,
-            _apply_horizontal_symmetry,
-        )
-        from .puzzle_io import save_puzzle
-        from .validator import validate_puzzle, _has_zero_adjacent
-        from .constants import MAX_SOLVER_STEPS
-        from .puzzle_builder import _reduce_clues, _build_puzzle_dict
+try:
+    from .puzzle_io import save_puzzle
+except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+    from puzzle_io import save_puzzle
 
-        # 標準ライブラリの ``types`` と名前が衝突しないよう ``puzzle_types`` に変更
-        from .puzzle_types import Puzzle
-    except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
-        # スクリプトとして直接実行されたときは同じディレクトリからインポートする
-        from loop_builder import (
-            _create_empty_edges,
-            _generate_random_loop,
-            _count_edges,
-            _calculate_curve_ratio,
-            _apply_rotational_symmetry,
-            _apply_vertical_symmetry,
-            _apply_horizontal_symmetry,
-        )
-        from puzzle_io import save_puzzle
-        from validator import validate_puzzle, _has_zero_adjacent
-        from constants import MAX_SOLVER_STEPS
-        from puzzle_builder import _reduce_clues, _build_puzzle_dict
-        from puzzle_types import Puzzle
+try:
+    from .validator import validate_puzzle, _has_zero_adjacent
+except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+    from validator import validate_puzzle, _has_zero_adjacent
+
+try:
+    from .constants import MAX_SOLVER_STEPS
+except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+    from constants import MAX_SOLVER_STEPS
+
+try:
+    from .puzzle_builder import _reduce_clues, _build_puzzle_dict, _optimize_clues
+except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+    from puzzle_builder import _reduce_clues, _build_puzzle_dict, _optimize_clues
+
+try:
+    # ``types`` モジュールと名前が衝突しないよう ``puzzle_types`` ファイルで定義
+    from .puzzle_types import Puzzle
+except ImportError:  # pragma: no cover - スクリプト実行時のフォールバック
+    from puzzle_types import Puzzle
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- generator モジュールの import ブロックを整理
- 不要な `else` ブロックを削除し読みやすく統一

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865c1050c70832c8ce35b55d506752a