### PR TITLE
Add pattern theme

### DIFF
--- a/MakeGridTraceSPECnew.md
+++ b/MakeGridTraceSPECnew.md
@@ -72,7 +72,8 @@ def generate_puzzle(
 - `seed`: 乱数シード。指定すると同じ盤面を再生成できます。
 - `return_stats`: `True` にすると生成過程の統計情報も返します。
 
-現行実装では `theme` に `"border"` を指定可能で、`timeout_s` も利用できます。
+現行実装では `theme` に `"border"` や `"maze"`, `"spiral"`, `"pattern"` を指定
+可能で、`timeout_s` も利用できます。
 
 ### 3.2 その他の関数
 
@@ -174,7 +175,8 @@ flowchart TD
 ## 9. 今後の開発方針
 
 1. **テーマ (`theme`) 拡充**
-   - 現在は `"border"` のみ実装済み。今後は複数パターンを追加する
+   - `"pattern"` テーマを追加し、3x3 や 4x4 のループを敷き詰めて大きな
+     ループを構成できるようになった
 2. **品質指標 (Quality Score) 改良**
    - 曲率比率やヒント分散度に加え、より多くの統計情報から算出する
 3. **solverStats 出力**

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ python -m src.generator 4 4 --difficulty normal
 - `--difficulty` : 難易度ラベル。`easy` / `normal` / `hard` / `expert` から選択。省略すると `easy`。
 - `--symmetry` : `rotational`, `vertical`, `horizontal` のいずれかを指定すると
   回転対称・上下対称・左右対称の盤面を生成します。
-- `--theme` : `border` のほか `maze`, `spiral` を指定できます。テーマごとに
-  ループ形状が変わります。
+- `--theme` : `border`, `maze`, `spiral` のほか `pattern` を指定できます。小さな
+  ループパターンを敷き詰めた形状になります。
 - `--seed` : 乱数シード。再現したいときに数値を指定します。
 - `--timeout` : 生成処理のタイムアウト秒数。指定しない場合は無制限。
 - `--parallel` : 並列生成プロセス数。複数指定すると複数プロセスで同時に生成を試行

--- a/src/generator.py
+++ b/src/generator.py
@@ -27,6 +27,7 @@ try:
     from .loop_builder import (
         _create_empty_edges,
         _generate_random_loop,
+        combine_patterns,
         _count_edges,
         _calculate_curve_ratio,
         _apply_rotational_symmetry,
@@ -37,12 +38,13 @@ except ImportError:  # pragma: no cover - スクリプト実行時のフォー�
     from loop_builder import (
         _create_empty_edges,
         _generate_random_loop,
+        combine_patterns,
         _count_edges,
         _calculate_curve_ratio,
         _apply_rotational_symmetry,
         _apply_vertical_symmetry,
         _apply_horizontal_symmetry,
-    )
+    )  # type: ignore
 
 try:
     from .puzzle_io import save_puzzle
@@ -153,6 +155,8 @@ def _create_loop(
             for r in range(size.rows):
                 edges["vertical"][r][0] = True
                 edges["vertical"][r][size.cols] = True
+        elif theme == "pattern":
+            edges = combine_patterns(size, rng)
         elif theme == "maze":
             # ランダムループを複数回生成し、より長く曲がりの多いものを採用する
             best_edges = None

--- a/src/pattern_builder.py
+++ b/src/pattern_builder.py
@@ -1,0 +1,27 @@
+"""小サイズのループパターンを定義するモジュール"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def _make_square_pattern(size: int) -> Dict[str, List[List[bool]]]:
+    """正方形の外周だけを通る単純なループを作成する"""
+    horizontal = [[False for _ in range(size)] for _ in range(size + 1)]
+    vertical = [[False for _ in range(size + 1)] for _ in range(size)]
+    for c in range(size):
+        horizontal[0][c] = True
+        horizontal[size][c] = True
+    for r in range(size):
+        vertical[r][0] = True
+        vertical[r][size] = True
+    return {"horizontal": horizontal, "vertical": vertical}
+
+
+# 実際に利用するパターンを辞書にまとめる
+PATTERNS: Dict[int, Dict[str, List[List[bool]]]] = {
+    3: _make_square_pattern(3),
+    4: _make_square_pattern(4),
+}
+
+__all__ = ["PATTERNS"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -106,6 +106,17 @@ def test_generate_puzzle_theme_spiral() -> None:
     assert puzzle["generationParams"]["theme"] == "spiral"
 
 
+@pytest.mark.slow
+def test_generate_puzzle_pattern() -> None:
+    """10x10 サイズで pattern テーマが使えるか確認"""
+    puzzle = cast(
+        Dict[str, Any],
+        generator.generate_puzzle(10, 10, difficulty="easy", theme="pattern", seed=21),
+    )
+    validator.validate_puzzle(puzzle)
+    assert puzzle["theme"] == "pattern"
+
+
 def test_validate_puzzle() -> None:
     puzzle = cast(Dict[str, Any], generator.generate_puzzle(4, 4, seed=0))
     # エラーが出ないことを確認


### PR DESCRIPTION
## Summary
- add small loop patterns
- tile patterns to build loops
- integrate combine_patterns with generator
- document new theme in README and spec
- test generation using the pattern theme

## Testing
- `black -q src tests`
- `flake8`
- `mypy --ignore-missing-imports src` *(fails: Name already defined)*
- `pytest -m "not slow" -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6865d3c09070832ca95a9d3570fe0bcd