### PR TITLE
Implement zero-only line validation

### DIFF
--- a/src/validator.py
+++ b/src/validator.py
@@ -54,6 +54,20 @@ def count_zero_adjacent(clues: List[List[int]]) -> int:
     return count
 
 
+def _has_zero_only_line(clues: List[List[int]]) -> bool:
+    """行または列がすべて 0 かどうかを判定するヘルパー関数"""
+
+    rows = len(clues)
+    cols = len(clues[0]) if rows > 0 else 0
+    for r in range(rows):
+        if all(clues[r][c] == 0 for c in range(cols)):
+            return True
+    for c in range(cols):
+        if all(clues[r][c] == 0 for r in range(rows)):
+            return True
+    return False
+
+
 def validate_puzzle(puzzle: Puzzle) -> None:
     """盤面データが仕様を満たすか簡易チェックする"""
 
@@ -159,5 +173,13 @@ def validate_puzzle(puzzle: Puzzle) -> None:
     if curve_ratio < 0.15:
         raise ValueError("線カーブ比率がハード制約を満たしていません")
 
+    if _has_zero_only_line(clues_full):
+        raise ValueError("行または列に 0 だけのものがあります")
 
-__all__ = ["validate_puzzle", "_has_zero_adjacent", "count_zero_adjacent"]
+
+__all__ = [
+    "validate_puzzle",
+    "_has_zero_adjacent",
+    "count_zero_adjacent",
+    "_has_zero_only_line",
+]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -179,6 +179,39 @@ def test_generator_zero_adjacent_soft() -> None:
     assert count >= 0
 
 
+def test_validate_puzzle_zero_only_row_fail() -> None:
+    size = solver.PuzzleSize(3, 3)
+    edges = loop_builder._create_empty_edges(size)
+    # 下側中央のセルだけを囲む小さなループを作成
+    edges["horizontal"][2][1] = True
+    edges["horizontal"][2][2] = True
+    edges["horizontal"][3][1] = True
+    edges["horizontal"][3][2] = True
+    edges["vertical"][2][1] = True
+    edges["vertical"][2][2] = True
+
+    clues_full = solver.calculate_clues(edges, size)
+    assert clues_full[0] == [0, 0, 0]
+    stats = solver.count_solutions(clues_full, size, limit=2, return_stats=True)[1]
+    puzzle = puzzle_builder._build_puzzle_dict(
+        size=size,
+        edges=edges,
+        clues=[[v for v in row] for row in clues_full],
+        clues_full=clues_full,
+        loop_length=loop_builder._count_edges(edges),
+        curve_ratio=loop_builder._calculate_curve_ratio(edges, size),
+        difficulty="easy",
+        solver_stats=stats,
+        symmetry=None,
+        theme=None,
+        generation_params={},
+        seed_hash="x",
+        partial=False,
+    )
+    with pytest.raises(ValueError):
+        validator.validate_puzzle(puzzle)
+
+
 def test_generate_puzzle_timeout() -> None:
     with pytest.raises(TimeoutError):
         generator.generate_puzzle(3, 3, timeout_s=0.0)


### PR DESCRIPTION
## Summary
- 新しいハード制約として行または列が全て0となる盤面を禁止
- `validator` に `_has_zero_only_line` を追加
- `validate_puzzle` でこのチェックを実施
- テスト `test_validate_puzzle_zero_only_row_fail` を追加

## Testing
- `pytest -q -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_6865d809aff4832cbb3757512ec152d6