### PR TITLE
Add timeout reason field to puzzles

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -403,6 +403,7 @@ def generate_puzzle(
         if timeout_s is not None and time.perf_counter() - start_time > timeout_s:
             if best_puzzle is not None:
                 best_puzzle["partial"] = True
+                best_puzzle["reason"] = "timeout"
                 return best_puzzle
             raise TimeoutError("generation timed out")
         edges, loop_length, curve_ratio = _generate_loop_with_symmetry(

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -237,6 +237,7 @@ def _build_puzzle_dict(
     generation_params: Dict[str, Any],
     seed_hash: str,
     partial: bool = False,
+    reason: str | None = None,
 ) -> Puzzle:
     """パズル用の辞書オブジェクトを構築するヘルパー関数"""
 
@@ -273,6 +274,8 @@ def _build_puzzle_dict(
         "createdAt": datetime.now(UTC).date().isoformat(),
         "partial": partial,
     }
+    if partial and reason is not None:
+        puzzle["reason"] = reason
     return puzzle
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -217,6 +217,32 @@ def test_generate_puzzle_timeout() -> None:
         generator.generate_puzzle(3, 3, timeout_s=0.0)
 
 
+def test_partial_reason_timeout() -> None:
+    size = solver.PuzzleSize(2, 2)
+    edges = loop_builder._create_empty_edges(size)
+    loop_builder._generate_random_loop(edges, size, random.Random(1))
+    clues = solver.calculate_clues(edges, size)
+    stats = solver.count_solutions(clues, size, limit=2, return_stats=True)[1]
+    puzzle = puzzle_builder._build_puzzle_dict(
+        size=size,
+        edges=edges,
+        clues=[[v for v in row] for row in clues],
+        clues_full=clues,
+        loop_length=loop_builder._count_edges(edges),
+        curve_ratio=loop_builder._calculate_curve_ratio(edges, size),
+        difficulty="easy",
+        solver_stats=stats,
+        symmetry=None,
+        theme=None,
+        generation_params={},
+        seed_hash="x",
+        partial=True,
+        reason="timeout",
+    )
+    assert puzzle["partial"] is True
+    assert puzzle["reason"] == "timeout"
+
+
 @pytest.mark.slow
 def test_generate_multiple_and_save(tmp_path: Path) -> None:
     puzzles = generator.generate_multiple_puzzles(3, 3, count_each=1, seed=5)


### PR DESCRIPTION
## Summary
- record timeout reason in `best_puzzle` when `generate_puzzle` times out
- extend `_build_puzzle_dict` to accept optional `reason`
- test that partial puzzles can include a timeout reason

## Testing
- `black . --check`
- `flake8`
- `mypy src --ignore-missing-imports --allow-redefinition --disable-error-code no-redef --disable-error-code arg-type --disable-error-code call-overload`
- `pytest -q` *(failed: KeyboardInterrupt after running several tests)*

------
https://chatgpt.com/codex/tasks/task_e_686a193ca2f0832c93c3d6b5b59cbb69