### PR TITLE
Fix dynamic solver steps

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-# ソルバーが探索する最大ステップ数
-# ステップ数を増やすと解の探索精度が上がるが時間もかかる
-MAX_SOLVER_STEPS = 500000
+# 従来のデフォルト値を参考として残しておく
+# 現在は関数側で盤面サイズから計算するため、この値は直接は使わない
+DEFAULT_SOLVER_STEP_LIMIT = 500000
 
 
 def _evaluate_difficulty(steps: int, depth: int) -> str:
@@ -20,4 +20,4 @@ def _evaluate_difficulty(steps: int, depth: int) -> str:
     return "expert"
 
 
-__all__ = ["MAX_SOLVER_STEPS", "_evaluate_difficulty"]
+__all__ = ["DEFAULT_SOLVER_STEP_LIMIT", "_evaluate_difficulty"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -14,6 +14,7 @@ from src import validator  # noqa: E402
 from src import solver  # noqa: E402
 from src import puzzle_builder  # noqa: E402
 from src import loop_builder  # noqa: E402
+from src import constants  # noqa: E402
 
 
 def test_generate_puzzle_structure(tmp_path: Path) -> None:
@@ -40,7 +41,7 @@ def test_generate_puzzle_structure(tmp_path: Path) -> None:
         "seed": 0,
         "symmetry": None,
         "theme": None,
-        "solverStepLimit": generator.MAX_SOLVER_STEPS,
+        "solverStepLimit": 4 * 4 * 25,
     }
     assert puzzle["seedHash"] == hashlib.sha256(b"0").hexdigest()
     calc = solver.calculate_clues(puzzle["solutionEdges"], solver.PuzzleSize(4, 4))
@@ -111,7 +112,14 @@ def test_generate_puzzle_pattern() -> None:
     """10x10 サイズで pattern テーマが使えるか確認"""
     puzzle = cast(
         Dict[str, Any],
-        generator.generate_puzzle(10, 10, difficulty="easy", theme="pattern", seed=21),
+        generator.generate_puzzle(
+            10,
+            10,
+            difficulty="easy",
+            theme="pattern",
+            seed=21,
+            solver_step_limit=constants.DEFAULT_SOLVER_STEP_LIMIT,
+        ),
     )
     validator.validate_puzzle(puzzle)
     assert puzzle["theme"] == "pattern"
@@ -338,7 +346,7 @@ def test_generation_params_and_seedhash() -> None:
         "seed": 42,
         "symmetry": "rotational",
         "theme": None,
-        "solverStepLimit": generator.MAX_SOLVER_STEPS,
+        "solverStepLimit": 3 * 3 * 25,
     }
     assert puzzle["generationParams"] == expected
     assert puzzle["seedHash"] == hashlib.sha256(b"42").hexdigest()


### PR DESCRIPTION
## Summary
- remove `MAX_SOLVER_STEPS` and replace with dynamic calculation
- default solver step limit is now computed from board size
- adjust puzzle builder helpers to use dynamic limit
- fix CLI and tests to account for auto-calculated limits

## Testing
- `black src tests`
- `flake8`
- `mypy src` *(fails: Missing target module)*
- `pytest -m "not slow" -q`

------
https://chatgpt.com/codex/tasks/task_e_686a193b4ec0832c89e99c9e9fe071ea