### PR TITLE
Implement B3 theme expansion

### DIFF
--- a/src/loop_wilson.py
+++ b/src/loop_wilson.py
@@ -22,7 +22,9 @@ from .loop_builder import (
 )
 
 
-def _vertex_degree(edges: Dict[str, List[List[bool]]], size: PuzzleSize, r: int, c: int) -> int:
+def _vertex_degree(
+    edges: Dict[str, List[List[bool]]], size: PuzzleSize, r: int, c: int
+) -> int:
     """頂点の接続数を求める小さなヘルパー"""
     deg = 0
     if c < size.cols and edges["horizontal"][r][c]:
@@ -100,6 +102,42 @@ def generate_loop(
                 if curve > best_curve:
                     best_edges = cand
                     best_curve = curve
+            if best_edges is not None:
+                edges = best_edges
+            else:
+                _generate_random_loop(edges, size, rng)
+        elif theme == "figure8":
+            # 回転対称のループを複数試し最も曲率が高いものを採用する
+            best_edges = None
+            best_curve = -1.0
+            for _ in range(10):
+                cand = _create_empty_edges(size)
+                _generate_random_loop(cand, size, rng)
+                if not _validate_edges(cand, size):
+                    continue
+                _apply_rotational_symmetry(cand, size)
+                curve = _calculate_curve_ratio(cand, size)
+                if curve > best_curve:
+                    best_edges = cand
+                    best_curve = curve
+            if best_edges is not None:
+                edges = best_edges
+            else:
+                _generate_random_loop(edges, size, rng)
+                _apply_rotational_symmetry(edges, size)
+        elif theme == "labyrinth":
+            # できるだけ長いループを選び迷路風にする
+            best_edges = None
+            best_len = -1
+            for _ in range(10):
+                cand = _create_empty_edges(size)
+                _generate_random_loop(cand, size, rng)
+                if not _validate_edges(cand, size):
+                    continue
+                length = _count_edges(cand)
+                if length > best_len:
+                    best_edges = cand
+                    best_len = length
             if best_edges is not None:
                 edges = best_edges
             else:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -20,7 +20,6 @@ from src import constants  # noqa: E402
 from src import sat_unique  # noqa: E402
 
 
-
 def test_generate_puzzle_structure(tmp_path: Path) -> None:
     puzzle = cast(Dict[str, Any], generator.generate_puzzle(4, 4, seed=0))
     # JSON に変換できるか確認
@@ -109,6 +108,26 @@ def test_generate_puzzle_theme_spiral() -> None:
     validator.validate_puzzle(puzzle)
     assert puzzle["theme"] == "spiral"
     assert puzzle["generationParams"]["theme"] == "spiral"
+
+
+def test_generate_puzzle_theme_figure8() -> None:
+    puzzle = cast(
+        Dict[str, Any],
+        generator.generate_puzzle(3, 3, difficulty="easy", theme="figure8", seed=13),
+    )
+    validator.validate_puzzle(puzzle)
+    assert puzzle["theme"] == "figure8"
+    assert puzzle["generationParams"]["theme"] == "figure8"
+
+
+def test_generate_puzzle_theme_labyrinth() -> None:
+    puzzle = cast(
+        Dict[str, Any],
+        generator.generate_puzzle(3, 3, difficulty="easy", theme="labyrinth", seed=14),
+    )
+    validator.validate_puzzle(puzzle)
+    assert puzzle["theme"] == "labyrinth"
+    assert puzzle["generationParams"]["theme"] == "labyrinth"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary
- add new themes `figure8` and `labyrinth`
- inject simple clue patterns with `_inject_clue_patterns`
- expose new themes via CLI
- test new themes

## Testing
- `flake8`
- `pytest -q` *(fails? passes?)*

------
https://chatgpt.com/codex/tasks/task_e_686a2dc34d4c832ca566187857df6b16