### PR TITLE
Implement Numba warm-up

### DIFF
--- a/src/loop_builder.py
+++ b/src/loop_builder.py
@@ -223,7 +223,7 @@ def _apply_horizontal_symmetry(
             vertical[r][sc] = val
 
 
-@njit
+@njit(cache=True)
 def _count_edges_bitboard(h: np.ndarray, v: np.ndarray) -> int:
     """NumPy 配列化された辺の数を数える"""
     count = 0
@@ -238,7 +238,7 @@ def _count_edges_bitboard(h: np.ndarray, v: np.ndarray) -> int:
     return count
 
 
-@njit
+@njit(cache=True)
 def _curve_ratio_bitboard(h: np.ndarray, v: np.ndarray, rows: int, cols: int) -> float:
     """曲率比率を NumPy 配列で高速計算する"""
     curve_count = 0
@@ -392,3 +392,15 @@ __all__ = [
     "_calculate_curve_ratio",
     "combine_patterns",
 ]
+
+
+def _warmup_numba() -> None:
+    """Numba コンパイルを事前に行うウォームアップ関数"""
+
+    # 1x1 のダミー配列を使い JIT を走らせる
+    dummy = np.zeros((1, 1), dtype=np.uint8)
+    _count_edges_bitboard(dummy, dummy)
+    _curve_ratio_bitboard(dummy, dummy, 0, 0)
+
+
+_warmup_numba()

--- a/src/puzzle_builder.py
+++ b/src/puzzle_builder.py
@@ -70,7 +70,7 @@ def _calculate_hint_dispersion(clues: List[List[int | None]]) -> float:
     return filled / total if total else 0.0
 
 
-@njit
+@njit(cache=True)
 def _quality_core(
     clues_arr: np.ndarray, curve_ratio: float, solver_steps: int, loop_length: int
 ) -> float:
@@ -417,3 +417,13 @@ __all__ = [
     "_calculate_quality_score",
     "_calculate_hint_dispersion",
 ]
+
+
+def _warmup_numba() -> None:
+    """Numba 関数の初回コンパイルを行う"""
+
+    dummy = np.zeros((1, 1), dtype=np.int8)
+    _quality_core(dummy, 0.0, 0, 0)
+
+
+_warmup_numba()


### PR DESCRIPTION
## Summary
- cache Numba functions
- add warm-up helpers for Numba compilation
- run tests excluding slow tests

## Testing
- `black -q .`
- `flake8`
- `mypy --ignore-missing-imports src` *(fails: Name already defined, etc.)*
- `pytest -q -m "not slow"`

------
https://chatgpt.com/codex/tasks/task_e_686ad6c0ce54832c8018916230e5c393