### PR TITLE
Update validation rules for borders

### DIFF
--- a/src/validator.py
+++ b/src/validator.py
@@ -153,6 +153,16 @@ def validate_puzzle(puzzle: Puzzle) -> None:
     if edge_count < 2 * (size.rows + size.cols):
         raise ValueError("ループ長がハード制約を満たしていません")
 
+    # 外周の各辺に 1 本も線が無い場合は無効とする
+    if not any(horizontal[0]):
+        raise ValueError("上辺に線がありません")
+    if not any(horizontal[size.rows]):
+        raise ValueError("下辺に線がありません")
+    if not any(vertical[r][0] for r in range(size.rows)):
+        raise ValueError("左辺に線がありません")
+    if not any(vertical[r][size.cols] for r in range(size.rows)):
+        raise ValueError("右辺に線がありません")
+
     clues_full = puzzle.get("cluesFull")
     if not isinstance(clues_full, list):
         raise ValueError("cluesFull フィールドが存在しません")
@@ -172,9 +182,6 @@ def validate_puzzle(puzzle: Puzzle) -> None:
     curve_ratio = _calculate_curve_ratio(edges, size)
     if curve_ratio < 0.10:
         raise ValueError("線カーブ比率がハード制約を満たしていません")
-
-    if _has_zero_only_line(clues_full):
-        raise ValueError("行または列に 0 だけのものがあります")
 
 
 __all__ = [

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -175,7 +175,13 @@ def test_validate_puzzle_fail() -> None:
 def test_zero_adjacent_allowed() -> None:
     size = solver.PuzzleSize(4, 4)
     edges = loop_builder._create_empty_edges(size)
-    loop_builder._generate_random_loop(edges, size, random.Random(1))
+    # 外周だけを通る単純なループを作成
+    for c in range(size.cols):
+        edges["horizontal"][0][c] = True
+        edges["horizontal"][size.rows][c] = True
+    for r in range(size.rows):
+        edges["vertical"][r][0] = True
+        edges["vertical"][r][size.cols] = True
     clues = solver.calculate_clues(edges, size)
     stats = solver.count_solutions(clues, size, limit=2, return_stats=True)[1]
     puzzle = puzzle_builder._build_puzzle_dict(
@@ -210,19 +216,18 @@ def test_generator_zero_adjacent_soft() -> None:
     assert count >= 0
 
 
-def test_validate_puzzle_zero_only_row_fail() -> None:
+def test_validate_puzzle_missing_border_fail() -> None:
     size = solver.PuzzleSize(3, 3)
     edges = loop_builder._create_empty_edges(size)
-    # 下側中央のセルだけを囲む小さなループを作成
-    edges["horizontal"][2][1] = True
-    edges["horizontal"][2][2] = True
-    edges["horizontal"][3][1] = True
-    edges["horizontal"][3][2] = True
-    edges["vertical"][2][1] = True
-    edges["vertical"][2][2] = True
+    # 右辺だけ線を引かないループを作成
+    for c in range(2):
+        edges["horizontal"][0][c] = True
+        edges["horizontal"][size.rows][c] = True
+    for r in range(size.rows):
+        edges["vertical"][r][0] = True
+        edges["vertical"][r][2] = True
 
     clues_full = solver.calculate_clues(edges, size)
-    assert clues_full[0] == [0, 0, 0]
     stats = solver.count_solutions(clues_full, size, limit=2, return_stats=True)[1]
     puzzle = puzzle_builder._build_puzzle_dict(
         size=size,


### PR DESCRIPTION
## Summary
- enforce that each border has at least one edge
- drop zero-only line restriction in validator
- adjust tests for new rules

## Testing
- `black -q src tests`
- `flake8 src tests`
- `mypy src` *(fails: missing stubs for pysat and others)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b28abff2c832cb59c0fb332463a30